### PR TITLE
Restore a location lost with the 4.14 merge

### DIFF
--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -4104,7 +4104,8 @@ and type_expect_
           (Pat.construct ~loc:default_loc
              (mknoloc (Longident.(Ldot (Lident "*predef*", "None"))))
              None)
-          (Exp.apply (Exp.extension (mknoloc "extension.escape", PStr []))
+          (Exp.apply ~loc:default_loc
+             (Exp.extension (mknoloc "extension.escape", PStr []))
              [Nolabel, default]);
        ]
       in


### PR DESCRIPTION
This allows merlin to work in defaults for optional arguments.