### PR TITLE
Fix bug in merge

### DIFF
--- a/src/ocaml/preprocess/lexer_raw.mll
+++ b/src/ocaml/preprocess/lexer_raw.mll
@@ -1044,6 +1044,14 @@ and skip_sharp_bang state = parse
   (* preprocessor support not implemented, not compatible with monadic
      interface *)
 
+  let token state lexbuf =
+    match Queue.take_opt deferred_tokens with
+    | None -> token state lexbuf
+    | Some { token; start_pos; end_pos } ->
+        lexbuf.lex_start_p <- start_pos;
+        lexbuf.lex_curr_p <- end_pos;
+        return token
+
   let rec token_without_comments state lexbuf =
     token state lexbuf >>= function
     | COMMENT _ ->


### PR DESCRIPTION
Restore custom `token` function that had been dropped in merge, and update it for the monadic interface used in merlin.