### PR TITLE
Import script pulls in new files added in flambda-backend

### DIFF
--- a/import-added-ocaml-source-files.sh
+++ b/import-added-ocaml-source-files.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Script arguments with their default values
+commitish=main
+repository=https://github.com/ocaml-flambda/flambda-backend
+subdirectory=ocaml
+
+function usage () {
+  cat <<USAGE
+Usage: $0 [COMMITISH [REPO [SUBDIRECTORY]]]
+
+Fetches any new files that previously hadn't been imported. This ignores
+files outside of *directories* that were previously imported,
+so if a whole new directory is added, you may need to manually
+add the new file.
+USAGE
+}
+
+if [[ $# -le 3 ]]; then
+  commitish="${1-$commitish}"
+  repository="${2-$repository}"
+  subdirectory="${3-$subdirectory}"
+else
+  usage >&2
+  exit 1
+fi
+
+case "${1-unused}" in
+  -h|-help|--help|-\?)
+    usage
+    exit 0
+    ;;
+esac
+
+# First, fetch the new flambda-backend sources (which include ocaml-jst).
+
+function sorted_files_at_committish() {
+  git ls-tree -r --name-only "$1" | sort
+}
+
+git fetch "$repository" "$commitish"
+rev=$(git rev-parse FETCH_HEAD)
+
+function files_new_at_fetch_head() {
+  comm -13 \
+    <(sorted_files_at_committish "$(cat upstream/ocaml_flambda/base-rev.txt)") \
+    <(sorted_files_at_committish FETCH_HEAD)
+}
+
+function directories_from_previous_import() {
+  cd upstream/ocaml_flambda; ls -d */ | xargs -n 1 printf "^$subdirectory/%s\n"
+}
+
+files=$(files_new_at_fetch_head | grep -f <(directories_from_previous_import))
+
+echo "The script will attempt to import these files added to directories that had previously been imported:"
+echo "$files"
+
+for file in $files; do
+  read -p "Import new file $file? [Y/n] " answer
+  case ${answer} in
+    y|Y|"" )
+      echo "Importing $file"
+      ocaml_flambda_file=upstream/ocaml_flambda/"${file#$subdirectory/}"
+      git show "FETCH_HEAD:$file" > "$ocaml_flambda_file"
+      cp "$ocaml_flambda_file" src/$file
+      ;;
+    * )
+      echo "Skipping $file; run '$0' again in order to make a different decision"
+      ;;
+  esac
+done

--- a/import-ocaml-source.sh
+++ b/import-ocaml-source.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 # Script arguments with their default values
-repository=https://github.com/ocaml-flambda/flambda-backend
 commitish=main
+repository=https://github.com/ocaml-flambda/flambda-backend
 subdirectory=ocaml
 
 function usage () {
@@ -16,9 +18,11 @@ branch can be overridden by any commitish (branch, tag, full (not abbreviated!)
 commit hash, etc.), the repository can be overridden by any URL, and the
 subdirectory can be overriden by any path (including ".").
 
-To import new files from the compiler, first create matched pairs of empty files
-in this repository with the right names: one in "upstream/ocaml_flambda/", and
-one in "src/ocaml".  Then running the script will pull in the named file(s).
+This attempts to import new files from the compiler by running the
+"import_added_ocaml_source_files.sh" script. If that doesn't work, you can also
+try making matched pairs of files in this repository with the right names: one
+in "upstream/ocaml_flambda/", and one in "src/ocaml".  Then running the script
+will pull in the named file(s).
 USAGE
 }
 
@@ -53,11 +57,15 @@ if ! git diff --quiet; then
   exit 1
 fi
 
+
 # Used for patch output
 old_base_rev="$(cat upstream/ocaml_flambda/base-rev.txt)"
 current_head="$(git symbolic-ref --short HEAD)"
 
-# First, fetch the new flambda-backend sources (which include ocaml-jst) and
+# First, add any files that have been added since the last import.
+./import-added-ocaml-source-files.sh "$commitish" "$repository" "$subdirectory"
+
+# Then, fetch the new flambda-backend sources (which include ocaml-jst) and
 # copy into upstream/ocaml_flambda
 git fetch "$repository" "$commitish"
 rev=$(git rev-parse FETCH_HEAD)


### PR DESCRIPTION
Now, when you run `import-ocaml-source.sh`, you'll be prompted with new files that have been added (in directories that have previously been imported).

This automates an easy-to-forget step of the importing process. (Without this, the importing process just won't bring in new files, and you're left to figure out how to pull in those files.)

Testing:
```
$ ./import-ocaml-source.sh 
From https://github.com/ocaml-flambda/flambda-backend
 * branch                main       -> FETCH_HEAD
The script will attempt to import these files added to directories that had previously been imported:
ocaml/parsing/jane_asttypes.mli
ocaml/typing/mode.ml
ocaml/typing/mode.mli
ocaml/typing/uniqueness_analysis.ml
ocaml/typing/uniqueness_analysis.mli
Import new file ocaml/parsing/jane_asttypes.mli? [Y/n] n
Skipping ocaml/parsing/jane_asttypes.mli; run './import-added-ocaml-source-files.sh' again in order to make a different decision
Import new file ocaml/typing/mode.ml? [Y/n] 
Importing ocaml/typing/mode.ml
Import new file ocaml/typing/mode.mli? [Y/n] y
Importing ocaml/typing/mode.mli
Import new file ocaml/typing/uniqueness_analysis.ml? [Y/n] y
Importing ocaml/typing/uniqueness_analysis.ml
Import new file ocaml/typing/uniqueness_analysis.mli? [Y/n] y
Importing ocaml/typing/uniqueness_analysis.mli
```

You can also run just the `import-added-ocaml-source-files.sh` in isolation to just bring in new files, skipping everything else that `import-ocaml-source.sh` tries to do.
