### PR TITLE
Remove duplicate ignored flag

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -409,7 +409,7 @@ let ocaml_ignored_flags = [
   "-output-complete-obj"; "-output-obj"; "-p"; "-pack";
   "-remove-unused-arguments"; "-S"; "-shared"; "-unbox-closures"; "-v";
   "-verbose"; "-where";
-  "-no-absname"; "-no-g"; "-safe-matching"; "-no-auto-include-otherlibs";
+  "-no-absname"; "-no-g"; "-safe-matching";
 
   (* flambda-backend specific *)
   "-basic-block-sections";


### PR DESCRIPTION
just a little clean up, the flag `-no-auto-include-otherlibs` appeared twice in the whitelist - it should only appear under JS flags.