### PR TITLE
Layouts (Stage 4): print non-value layouts on type variables

### DIFF
--- a/src/analysis/type_utils.ml
+++ b/src/analysis/type_utils.ml
@@ -111,7 +111,8 @@ module Printtyp = struct
     Mtype.scrape_alias env mty
 
   let verbose_type_scheme env ppf t =
-    Printtyp.type_scheme ppf (expand_type env t)
+    Printtyp.type_scheme_for_merlin ppf (expand_type env t)
+      ~print_non_value_jkind_on_type_variables:true
 
   let verbose_type_declaration ~print_non_value_inferred_jkind env id ppf t =
     Printtyp.type_declaration_for_merlin id ppf (expand_type_decl env t)
@@ -128,7 +129,7 @@ module Printtyp = struct
 
   let type_scheme env ppf ty =
     (select_by_verbosity
-      ~default:type_scheme
+      ~default:(type_scheme_for_merlin ~print_non_value_jkind_on_type_variables:false)
       ~verbose:(verbose_type_scheme env)) ppf ty
 
   let type_declaration env id ppf =

--- a/src/ocaml/typing/printtyp.mli
+++ b/src/ocaml/typing/printtyp.mli
@@ -149,6 +149,21 @@ val type_declaration_for_merlin:
   print_non_value_inferred_jkind:bool ->
   Ident.t -> formatter -> type_declaration -> unit
 
+val type_scheme_for_merlin:
+    (* Like [type_scheme].
+
+       [print_non_value_jkind_on_type_variables] is a setting controlled
+       by merlin verbosity levels. When it's true, merlin will print
+       layout annotations on type variables when the layout isn't merely
+       value.
+
+       E.g. When this flag is [true],
+       ['a -> 'b] is printed as [('a : float64) -> 'b]
+       if ['a] has layout [float64] and ['b] has layout [value].
+    *)
+    print_non_value_jkind_on_type_variables:bool ->
+    formatter -> type_expr -> unit
+
 val tree_of_value_description: Ident.t -> value_description -> out_sig_item
 val value_description: Ident.t -> formatter -> value_description -> unit
 val label : formatter -> label_declaration -> unit
@@ -160,8 +175,7 @@ val tree_of_type_declaration:
 val add_type_declaration_to_preparation :
   Ident.t -> type_declaration -> unit
 val prepared_type_declaration: Ident.t -> formatter -> type_declaration -> unit
-val type_declaration:
-  Ident.t -> formatter -> type_declaration -> unit
+val type_declaration: Ident.t -> formatter -> type_declaration -> unit
 val tree_of_extension_constructor:
     Ident.t -> extension_constructor -> ext_status -> out_sig_item
 val add_extension_constructor_to_preparation :

--- a/tests/test-dirs/type-enclosing/jane-street.t/run.t
+++ b/tests/test-dirs/type-enclosing/jane-street.t/run.t
@@ -193,12 +193,12 @@ to print everything on one line.
   let poly3 (type a : float64) (x : a) = x
       ^
   With verbosity 0: "'a -> 'a"
-  With verbosity 1: "'a -> 'a"
+  With verbosity 1: "('a : float64) -> ('a : float64)"
   
   let poly4 (type (a : immediate) (b : value)) (f : a -> b -> _) = f
       ^
   With verbosity 0: "('a -> ('b -> 'c)) -> 'a -> ('b -> 'c)"
-  With verbosity 1: "('a -> ('b -> 'c)) -> 'a -> ('b -> 'c)"
+  With verbosity 1: "(('a : immediate) -> ('b -> 'c)) -> ('a : immediate) -> ('b -> 'c)"
   
 
 -parameter
@@ -265,12 +265,12 @@ to print everything on one line.
   let poly_client3 x = poly3 x
       ^
   With verbosity 0: "'a -> 'a"
-  With verbosity 1: "'a -> 'a"
+  With verbosity 1: "('a : float64) -> ('a : float64)"
   
   let poly_client4 x = poly4 x
       ^
   With verbosity 0: "('a -> ('b -> 'c)) -> 'a -> ('b -> 'c)"
-  With verbosity 1: "('a -> ('b -> 'c)) -> 'a -> ('b -> 'c)"
+  With verbosity 1: "(('a : immediate) -> ('b -> 'c)) -> ('a : immediate) -> ('b -> 'c)"
   
 
 -parameter
@@ -291,12 +291,12 @@ to print everything on one line.
   let poly_client3 x = poly3 x
                    ^
   With verbosity 0: "'a"
-  With verbosity 1: "'a"
+  With verbosity 1: "('a : float64)"
   
   let poly_client4 x = poly4 x
                    ^
   With verbosity 0: "'a -> ('b -> 'c)"
-  With verbosity 1: "'a -> ('b -> 'c)"
+  With verbosity 1: "('a : immediate) -> ('b -> 'c)"
   
 (V) Parameterized type
 - definition
@@ -336,7 +336,7 @@ to print everything on one line.
   type ('a : immediate) p2 = A of 'a [@@unboxed]
        ^
   With verbosity 0: "'a"
-  With verbosity 1: "'a"
+  With verbosity 1: "('a : immediate)"
   
 
 (V) Parameterized type client
@@ -357,7 +357,7 @@ to print everything on one line.
   let param_client2 (x : 'a p2) (a : 'a) = x, a
       ^
   With verbosity 0: "'a p2 -> 'a -> 'a p2 * 'a"
-  With verbosity 1: "'a p2 -> 'a -> 'a p2 * 'a"
+  With verbosity 1: "('a : immediate) p2 -> ('a : immediate) -> ('a : immediate) p2 * ('a : immediate)"
   
 
 - parameter
@@ -377,5 +377,5 @@ to print everything on one line.
   let param_client2 (x : 'a p2) (a : 'a) = x, a
                     ^
   With verbosity 0: "'a p2"
-  With verbosity 1: "'a p2  type ('a : immediate) p2 = A of 'a [@@unboxed]"
+  With verbosity 1: "('a : immediate) p2  type ('a : immediate) p2 = A of 'a [@@unboxed]"
   


### PR DESCRIPTION
It may seem like I've skipped Stage 3, but that's intentional. (The design I distributed internally uses Stage 3 to refer to "print universally quantified variables with layouts more often".)

This PR makes it so that layouts are printed on type variables when the user queries the type of an expression something twice. The relevant design choices:
  * This just applies to asking for the type of an expression.
  * I print the layout on all occurrences of the type variable. You could imagine printing it just on, say, the first. I think this is worse because it gives undue special status to the first occurrence. (I'm open to being convinced otherwise.)
  * I just print non-value layouts.