### PR TITLE
Add additional error checking around `MERLIN_TEST_OCAML_PATH`

### DIFF
--- a/tests/merlin-wrapper
+++ b/tests/merlin-wrapper
@@ -16,6 +16,12 @@ fi
 
 MERLIN_TEST_OCAMLLIB_PATH="$MERLIN_TEST_OCAML_PATH/lib/ocaml"
 
+if [ ! -d "$MERLIN_TEST_OCAMLLIB_PATH" ]; then
+    echo >&2 "Error: Directory $MERLIN_TEST_OCAMLLIB_PATH does not exist."
+    echo >&2 "Check that you've set MERLIN_TEST_OCAML_PATH correctly."
+    exit 1
+fi
+
 ocamlmerlin "$@" -ocamllib-path "$MERLIN_TEST_OCAMLLIB_PATH" \
     | jq 'del(.timing)' \
     | sed -e 's:"[^"]*lib/ocaml:"lib/ocaml:g' \

--- a/tests/ocamlc-wrapper
+++ b/tests/ocamlc-wrapper
@@ -8,4 +8,10 @@ fi
 
 MERLIN_TEST_OCAMLC_PATH="$MERLIN_TEST_OCAML_PATH/bin/ocamlc"
 
+if [ ! -f "$MERLIN_TEST_OCAMLC_PATH" ]; then
+    echo >&2 "Error: $MERLIN_TEST_OCAMLC_PATH does not exist."
+    echo >&2 "Check that you've set MERLIN_TEST_OCAML_PATH correctly."
+    exit 1
+fi
+
 "$MERLIN_TEST_OCAMLC_PATH" "$@"


### PR DESCRIPTION
If you remember to set `MERLIN_TEST_OCAML_PATH` but typo in the value, the tests will run but give weird errors that could be misinterpreted as a bug in your merlin changes.  This adds a check that the relevant files appear to be present at the given location and errors if not, rather than running the tests with a bad value.