### PR TITLE
Regression test for worse documentation result produced in bin-annot-cms mode

### DIFF
--- a/tests/test-dirs/document/module-doc-with-attribute.t
+++ b/tests/test-dirs/document/module-doc-with-attribute.t
@@ -1,0 +1,58 @@
+  $ cat >dune-project <<EOF
+  > (lang dune 2.0)
+  > EOF
+
+  $ cat >lib.mli <<EOF
+  > (****************)
+  > (* SOME LICENCE *)
+  > (****************)
+  > 
+  > [@@@ocaml.text "Documentation of Lib"]
+  > 
+  > [@@@ocaml.doc "Documentation of Lib.a"]
+  > type a = int
+  > EOF
+
+  $ cat >lib.ml <<EOF
+  > type a = int
+  > EOF
+
+  $ cat >libimpl.ml <<EOF
+  > (****************)
+  > (* SOME LICENCE *)
+  > (****************)
+  > 
+  > [@@@ocaml.text "Documentation of Libimpl"]
+  > 
+  > [@@@ocaml.doc "Documentation of Libimpl.a"]
+  > type a = int
+  > EOF
+
+  $ cat >main.ml <<EOF
+  > type t = Lib.a
+  > type u = Libimpl.a
+  > EOF
+
+  $ cat >dune <<EOF
+  > (executable (name main))
+  > EOF
+
+  $ $OCAMLC -bin-annot-cms -o main.exe lib.mli lib.ml libimpl.ml main.ml
+
+The licence is correctly ignored when looking for the doc of Lib
+  $ $MERLIN single document -position 1:11 \
+  > -filename main.ml <main.ml
+  {
+    "class": "return",
+    "value": "No documentation available",
+    "notifications": []
+  }
+
+Same when the doc is in the ml file
+  $ $MERLIN single document -position 2:11 \
+  > -filename main.ml <main.ml
+  {
+    "class": "return",
+    "value": "No documentation available",
+    "notifications": []
+  }


### PR DESCRIPTION
Cf. `tests/test-dirs/document/module-doc.t`, which has the good output.

Problem: requesting the documentation for a module from merlin produces a bad result ("No documentation available") even when the module has a top-level doc comment.

Two ingredients appear to be necessary:
  * The user wrote `[@@@ocaml.doc "doc comment here"]` instead of `(** doc comment here *)`. (Or the user ran a ppx preprocessor.)
  * The user passes `-bin-annot-cms` to the compiler instead of `-bin-annot`.

Tracked in internal ticket 2135.