### PR TITLE
Test demonstrating a bug: merlin-destruct raises for some aliases to GADTs

### DIFF
--- a/tests/test-dirs/destruct/issue.t
+++ b/tests/test-dirs/destruct/issue.t
@@ -17,6 +17,12 @@
 
   $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
 
+Currently, there is a bug, and merlin-destruct raises. Pass [-log-file -] to get
+the below to log some additional diagnostics to stderr. In brief, it looks like
+merlin-destruct is finding that all constructors of [Gadt.u] are ill-typed in
+this position, but not for any good reason -- the fact that they're in a
+separate module seem to have something to do with it.
+
   $ $MERLIN single case-analysis -I lib -start 3:5 -end 3:5 -filename client.ml <<EOF
   > let f (Packed t : Gadt.packed) =
   >   match (t : _ Gadt.t) with

--- a/tests/test-dirs/destruct/issue.t
+++ b/tests/test-dirs/destruct/issue.t
@@ -1,0 +1,48 @@
+  $ mkdir lib
+  $ cat >lib/gadt.ml <<EOF
+  > type _ u =
+  >   | A : A.t u
+  >   | B : B.t u
+  > type packed = Packed : _ u -> packed
+  > type 'a t = 'a u
+  > EOF
+
+  $ cat >lib/a.ml <<EOF
+  > type t = int
+  > EOF
+
+  $ cat >lib/b.ml <<EOF
+  > type t = string
+  > EOF
+
+  $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
+
+  $ $MERLIN single case-analysis -I lib -start 3:5 -end 3:5 -filename client.ml <<EOF
+  > let f (Packed t : Gadt.packed) =
+  >   match (t : _ Gadt.t) with
+  >   | _ -> assert false
+  > EOF
+  {
+    "class": "exception",
+    "value": "File \"src/analysis/destruct.ml\", line 663, characters 14-20: Assertion failed
+  Raised at Merlin_analysis__Destruct.node in file \"src/analysis/destruct.ml\", line 663, characters 14-26
+  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
+  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
+  Called from Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 83, characters 10-14
+  Re-raised at Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 85, characters 38-45
+  Called from Ocaml_typing__Persistent_env.without_cmis in file \"src/ocaml/typing/persistent_env.ml\", line 194, characters 10-109
+  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
+  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
+  Called from Dune__exe__New_commands.run in file \"src/frontend/ocamlmerlin/new/new_commands.ml\", line 65, characters 15-53
+  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
+  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
+  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
+  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
+  Called from Stdlib__Fun.protect in file \"fun.ml\", line 33, characters 8-15
+  Re-raised at Stdlib__Fun.protect in file \"fun.ml\", line 38, characters 6-52
+  Called from Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 18, characters 8-38
+  Re-raised at Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 20, characters 42-53
+  Called from Dune__exe__New_merlin.run.(fun) in file \"src/frontend/ocamlmerlin/new/new_merlin.ml\", line 101, characters 14-110
+  ",
+    "notifications": []
+  }


### PR DESCRIPTION
If `u` is an alias to GADT `t`, then it's possible to arrange for merlin-destruct to raise on a term of type `(x : u)`. This PR adds a test demonstrating as such.

Unfortunately we have introduced this bug: it's not present in `ocaml/merlin` at main or at the 501-preview branch.