### PR TITLE
Workaround for gadt bug in merlin destruct

### DIFF
--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -659,8 +659,12 @@ let rec node config source selected_node parents =
             let ty = patt.Typedtree.pat_type in
             begin match gen_patterns patt.Typedtree.pat_env ty with
             | [] ->
-              (* gen_patterns might raise Not_allowed, but should never return [] *)
-              assert false
+                (* gen_patterns might raise Not_allowed, but should never return [].
+                   Nonetheless, we've found it to return [] in a hard-to-describe
+                   set of circumstances, so we report an error message rather
+                   than raising (see the test containing the below string).
+                *)
+              raise (Not_allowed "type that merlin doesn't know enough about")
             | [ more_precise ] ->
               (* If only one pattern is generated, then we're only refining the
                 current pattern, not generating new branches. *)

--- a/tests/test-dirs/destruct/issue.t
+++ b/tests/test-dirs/destruct/issue.t
@@ -17,6 +17,12 @@
 
   $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
 
+Currently, there is a bug, and merlin-destruct raises. Pass [-log-file -] to get
+the below to log some additional diagnostics to stderr. In brief, it looks like
+merlin-destruct is finding that all constructors of [Gadt.u] are ill-typed in
+this position, but not for any good reason -- the fact that they're in a
+separate module seem to have something to do with it.
+
   $ $MERLIN single case-analysis -I lib -start 3:5 -end 3:5 -filename client.ml <<EOF
   > let f (Packed t : Gadt.packed) =
   >   match (t : _ Gadt.t) with

--- a/tests/test-dirs/destruct/issue.t
+++ b/tests/test-dirs/destruct/issue.t
@@ -17,7 +17,7 @@
 
   $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
 
-Currently, there is a bug, and merlin-destruct raises. Pass [-log-file -] to get
+Currently, there is a bug, and merlin-destruct doesn't do a good job. Pass [-log-file -] to get
 the below to log some additional diagnostics to stderr. In brief, it looks like
 merlin-destruct is finding that all constructors of [Gadt.u] are ill-typed in
 this position, but not for any good reason -- the fact that they're in a
@@ -29,26 +29,7 @@ separate module seem to have something to do with it.
   >   | _ -> assert false
   > EOF
   {
-    "class": "exception",
-    "value": "File \"src/analysis/destruct.ml\", line 663, characters 14-20: Assertion failed
-  Raised at Merlin_analysis__Destruct.node in file \"src/analysis/destruct.ml\", line 663, characters 14-26
-  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
-  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
-  Called from Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 83, characters 10-14
-  Re-raised at Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 85, characters 38-45
-  Called from Ocaml_typing__Persistent_env.without_cmis in file \"src/ocaml/typing/persistent_env.ml\", line 194, characters 10-109
-  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
-  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
-  Called from Dune__exe__New_commands.run in file \"src/frontend/ocamlmerlin/new/new_commands.ml\", line 65, characters 15-53
-  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
-  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
-  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
-  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
-  Called from Stdlib__Fun.protect in file \"fun.ml\", line 33, characters 8-15
-  Re-raised at Stdlib__Fun.protect in file \"fun.ml\", line 38, characters 6-52
-  Called from Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 18, characters 8-38
-  Re-raised at Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 20, characters 42-53
-  Called from Dune__exe__New_merlin.run.(fun) in file \"src/frontend/ocamlmerlin/new/new_merlin.ml\", line 101, characters 14-110
-  ",
+    "class": "error",
+    "value": "Destruct not allowed on type that merlin doesn't know enough about",
     "notifications": []
   }

--- a/tests/test-dirs/destruct/issue.t
+++ b/tests/test-dirs/destruct/issue.t
@@ -1,0 +1,48 @@
+  $ mkdir lib
+  $ cat >lib/gadt.ml <<EOF
+  > type _ u =
+  >   | A : A.t u
+  >   | B : B.t u
+  > type packed = Packed : _ u -> packed
+  > type 'a t = 'a u
+  > EOF
+
+  $ cat >lib/a.ml <<EOF
+  > type t = int
+  > EOF
+
+  $ cat >lib/b.ml <<EOF
+  > type t = string
+  > EOF
+
+  $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
+
+  $ $MERLIN single case-analysis -I lib -start 3:5 -end 3:5 -filename client.ml <<EOF
+  > let f (Packed t : Gadt.packed) =
+  >   match (t : _ Gadt.t) with
+  >   | _ -> assert false
+  > EOF
+  {
+    "class": "exception",
+    "value": "File \"src/analysis/destruct.ml\", line 663, characters 14-20: Assertion failed
+  Raised at Merlin_analysis__Destruct.node in file \"src/analysis/destruct.ml\", line 663, characters 14-26
+  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
+  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
+  Called from Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 83, characters 10-14
+  Re-raised at Merlin_utils__Misc.protect_refs.(fun) in file \"src/utils/misc.ml\", line 85, characters 38-45
+  Called from Ocaml_typing__Persistent_env.without_cmis in file \"src/ocaml/typing/persistent_env.ml\", line 194, characters 10-109
+  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
+  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
+  Called from Dune__exe__New_commands.run in file \"src/frontend/ocamlmerlin/new/new_commands.ml\", line 65, characters 15-53
+  Called from Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 684, characters 8-12
+  Re-raised at Merlin_utils__Std.let_ref in file \"src/utils/std.ml\", line 686, characters 30-39
+  Called from Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 46, characters 8-15
+  Re-raised at Merlin_utils__Misc.try_finally in file \"src/utils/misc.ml\", line 63, characters 10-24
+  Called from Stdlib__Fun.protect in file \"fun.ml\", line 33, characters 8-15
+  Re-raised at Stdlib__Fun.protect in file \"fun.ml\", line 38, characters 6-52
+  Called from Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 18, characters 8-38
+  Re-raised at Merlin_kernel__Mocaml.with_state in file \"src/kernel/mocaml.ml\", line 20, characters 42-53
+  Called from Dune__exe__New_merlin.run.(fun) in file \"src/frontend/ocamlmerlin/new/new_merlin.ml\", line 101, characters 14-110
+  ",
+    "notifications": []
+  }


### PR DESCRIPTION
See https://github.com/janestreet/merlin-jst/pull/36 for the original bug report. This PR is not a principled fix, it's just a better user experience: report an error message (that still admits that merlin just hasn't done a very good job here) rather than a stack trace.