### PR TITLE
Fix #44 to use the new API for `Mode`

### DIFF
--- a/src/analysis/stack_or_heap_enclosing.ml
+++ b/src/analysis/stack_or_heap_enclosing.ml
@@ -4,7 +4,7 @@ let log_section = "stack-or-heap-enclosing"
 let { Logger.log } = Logger.for_section log_section
 
 type stack_or_heap =
-  | Alloc_mode of Mode.Alloc.t
+  | Alloc_mode of Mode.Alloc.r
   | No_alloc of { reason : string }
   | Unexpected_no_alloc
 

--- a/src/analysis/stack_or_heap_enclosing.mli
+++ b/src/analysis/stack_or_heap_enclosing.mli
@@ -20,7 +20,7 @@
 val log_section : string
 
 type stack_or_heap =
-  | Alloc_mode of Mode.Alloc.t
+  | Alloc_mode of Mode.Alloc.r
   | No_alloc of { reason : string }
   | Unexpected_no_alloc
 


### PR DESCRIPTION
#44 was rebased on top of #42 / #43 when it was merged. This made the code in #44 stop building because it used the argument-less version of `Mode.Alloc.t`, which now takes a type argument.

This PR fixes that.