### PR TITLE
Ignore SIGPIPE in the Merlin server process

### DIFF
--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -65,6 +65,8 @@ module Server = struct
     | None ->
       Logger.log ~section:"server" ~title:"cannot setup listener" ""
     | Some server ->
+      (* If the client closes its connection, don't let it kill us with a SIGPIPE. *)
+      let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
       loop (File_id.get Sys.executable_name) server;
       Os_ipc.server_close server
 end


### PR DESCRIPTION
The merlin server writes to pipes received from the merlin client process.  If the read end of those pipes is closed, e.g. because the merlin client process was killed, then when the server writes to the pipe it will generate a SIGPIPE.  This kills the Merlin server. Ignore the SIGPIPE instead of unnecessarily dying.

The fact that you get SIGPIPE when you write to a closed pipe is a classic Unix footgun, and this is the usual resolution.  Another solution is to avoid pipes (in favor of e.g. socketpairs), but we can't do that because we write directly to the file descriptors received from the client.