### PR TITLE
Call flush_all twice when closing a client connection

### DIFF
--- a/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
+++ b/src/frontend/ocamlmerlin/ocamlmerlin_server.ml
@@ -19,7 +19,12 @@ module Server = struct
     Os_ipc.context_setup context;
     let close_with return_code =
       flush_all ();
-      Os_ipc.context_close context ~return_code
+      Os_ipc.context_close context ~return_code;
+      (* The first flush may have failed due to IO errors, so flush again now that we've
+         reset our file descriptors.  This may cause us to send random output to the
+         server's stdout and stderr, but it's better than sending random output to the
+         next client to connect. *)
+      flush_all ()
     in
     match process_request client with
     | code -> close_with code


### PR DESCRIPTION
The Merlin server computes responses in response to client requests.  Sometimes, it can
erroneously write a response from a previous client to a later client, causing multiple
responses to be returned.  I've figured out why this happens and fixed it; it's yet
another wacky collision between the Merlin server's somewhat unusual architecture and the
reality of Unix.

Specifically, the output channels might still have data in their buffers when we get to
the next client.  We call flush_all to try and prevent that, but that can fail with an IO
error, leaving the data in the buffer, and causing it to be written out for the next
client.

Ideally we'd just discard the buffered data for any channel that has an IO error, but I
doubt that's possible with the stdlib channels - I haven't looked in detail though.
Instead, we just flush the channels into the server's initial file descriptors.  That's
probably /dev/null or some logfiles, so it's an acceptable place to send that useless
data.

It's somewhat hard to reproduce this behavior, but repeatedly creating a client and then
killing it before sending all its input input is semi-reliable.