### PR TITLE
Fix allocation analysis

### DIFF
--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -307,12 +307,15 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
           | Stack_or_heap_enclosing.No_alloc { reason }, true ->
               ret (`String ("not an allocation (" ^ reason ^ ")"))
           | Stack_or_heap_enclosing.Alloc_mode alloc_mode, true ->
-              let str =
-                match alloc_mode |> Mode.Alloc.proj (Comonadic Areality) |> Mode.Locality.Guts.check_const_conservative with
-                | Some Global -> "heap"
-                | Some Local -> "stack"
-                | None -> "could be stack or heap"
-              in ret (`String str)
+            let locality = alloc_mode 
+                           |> Mode.Alloc.proj (Comonadic Areality) 
+                           |> Mode.Locality.Guts.check_const_conservative 
+            in
+            let str = match locality with
+              | Some Global -> "heap"
+              | Some Local -> "stack"
+              | None -> "could be stack or heap"
+            in ret (`String str)
           | Stack_or_heap_enclosing.Unexpected_no_alloc, true ->
               ret (`String "unknown (does your code contain a type error?)")
           | _, false -> ret (`Index i)

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -275,6 +275,8 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
     to_string ()
 
   | Stack_or_heap_enclosing (pos, index) ->
+    let typer = Mpipeline.typer_result pipeline in
+
     (* Optimise allocations only on programs that have type-checked. *)
     let errors =
       Mpipeline.reader_lexer_errors pipeline @
@@ -288,7 +290,6 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
             | _ -> true)
     then Typecore.optimise_allocations ();
 
-    let typer = Mpipeline.typer_result pipeline in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let structures = Mbrowse.enclosing pos
       [Mbrowse.of_typedtree (Mtyper.get_typedtree typer)] in

--- a/tests/test-dirs/stack-or-heap.t/closures.ml
+++ b/tests/test-dirs/stack-or-heap.t/closures.ml
@@ -24,6 +24,11 @@ let f =
       (* ^ *)
 ;;
 
+let f x =
+  exclave_ function | y -> y
+               (* ^ *)
+;;
+
 let f = (function | x -> x)
                        (* ^ *)
 

--- a/tests/test-dirs/stack-or-heap.t/closures.ml
+++ b/tests/test-dirs/stack-or-heap.t/closures.ml
@@ -24,11 +24,6 @@ let f =
       (* ^ *)
 ;;
 
-let f =
-  exclave_ function | x -> x
-               (* ^ *)
-;;
-
 let f = (function | x -> x)
                        (* ^ *)
 

--- a/tests/test-dirs/stack-or-heap.t/run.t
+++ b/tests/test-dirs/stack-or-heap.t/run.t
@@ -328,6 +328,14 @@ how to produce valid json.
   
   "heap"
   
+  |  exclave_ function | y -> y
+  |                  ^
+  
+  |  exclave_ function | y -> y
+  |           ^^^^^^^^^^^^^^^^^
+  
+  "stack"
+  
   |let f = (function | x -> x)
   |                          ^
   
@@ -590,4 +598,36 @@ how to produce valid json.
   |          ^^^^^^^^^^^
   
   "could be stack or heap"
+  
+  |  let z = Some x in
+  |               ^
+  
+  |  let z = Some x in
+  |          ^^^^^^
+  
+  "could be stack or heap"
+  
+  |  let z = Some x in
+  |               ^
+  
+  |  let z = Some x in
+  |          ^^^^^^
+  
+  "stack"
+  
+  |  let z = Some x in
+  |               ^
+  
+  |  let z = Some x in
+  |          ^^^^^^
+  
+  "could be stack or heap"
+  
+  |  let z = Some y in
+  |               ^
+  
+  |  let z = Some y in
+  |          ^^^^^^
+  
+  "heap"
   

--- a/tests/test-dirs/stack-or-heap.t/run.t
+++ b/tests/test-dirs/stack-or-heap.t/run.t
@@ -631,3 +631,91 @@ how to produce valid json.
   
   "heap"
   
+  |  let z = [x, Some y] in
+  |                   ^
+  
+  |  let z = [x, Some y] in
+  |              ^^^^^^
+  
+  "stack"
+  
+  |  let z = [x, Some y] in
+  |                   ^
+  
+  |  let z = [x, Some y] in
+  |              ^^^^^^
+  
+  "could be stack or heap"
+  
+  |    | None -> [Some y]
+  |                    ^
+  
+  |    | None -> [Some y]
+  |               ^^^^^^
+  
+  "stack"
+  
+  |    | None -> [Some y]
+  |                    ^
+  
+  |    | None -> [Some y]
+  |               ^^^^^^
+  
+  "could be stack or heap"
+  
+  |    | None -> [Some y]
+  |                    ^
+  
+  |    | None -> [Some y]
+  |               ^^^^^^
+  
+  "heap"
+  
+  |  [x; Some y]
+  |           ^
+  
+  |  [x; Some y]
+  |      ^^^^^^
+  
+  "heap"
+  
+  |  exclave_ [x; Some y]
+  |                    ^
+  
+  |  exclave_ [x; Some y]
+  |               ^^^^^^
+  
+  "stack"
+  
+  |    let z = Some x in
+  |                 ^
+  
+  |    let z = Some x in
+  |            ^^^^^^
+  
+  "could be stack or heap"
+  
+  |  let z = [foo; Some bar] in
+  |                     ^
+  
+  |  let z = [foo; Some bar] in
+  |                ^^^^^^^^
+  
+  "could be stack or heap"
+  
+  |let g x = 5 + local_function (Some x)
+  |                                   ^
+  
+  |let g x = 5 + local_function (Some x)
+  |                             ^^^^^^^^
+  
+  "could be stack or heap"
+  
+  |let g x = global_function (Some x)
+  |                                ^
+  
+  |let g x = global_function (Some x)
+  |                          ^^^^^^^^
+  
+  "heap"
+  

--- a/tests/test-dirs/stack-or-heap.t/run.t
+++ b/tests/test-dirs/stack-or-heap.t/run.t
@@ -91,7 +91,7 @@ how to produce valid json.
   |  Some (g z)
   |  ^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  exclave_ Some (g z)
   |                 ^
@@ -99,7 +99,7 @@ how to produce valid json.
   |  exclave_ Some (g z)
   |           ^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  let z = Some (g x) in
   |                ^
@@ -107,7 +107,7 @@ how to produce valid json.
   |  let z = Some (g x) in
   |          ^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  None
   |    ^
@@ -131,7 +131,7 @@ how to produce valid json.
   |  f (Some x);
   |    ^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  f (local_ Some x);
   |                 ^
@@ -139,7 +139,7 @@ how to produce valid json.
   |  f (local_ Some x);
   |    ^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  f (Some x)
   |          ^
@@ -147,7 +147,7 @@ how to produce valid json.
   |  f (Some x)
   |    ^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let g x = f (Some x) [@nontail]
   |                  ^
@@ -155,7 +155,7 @@ how to produce valid json.
   |let g x = f (Some x) [@nontail]
   |            ^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  Box (g z)
   |       ^
@@ -174,7 +174,7 @@ how to produce valid json.
   |  `Some (g z)
   |  ^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  exclave_ `Some (g z)
   |                  ^
@@ -182,7 +182,7 @@ how to produce valid json.
   |  exclave_ `Some (g z)
   |           ^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  let z = `Some (g x) in
   |                 ^
@@ -190,7 +190,7 @@ how to produce valid json.
   |  let z = `Some (g x) in
   |          ^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  `None
   |     ^
@@ -218,7 +218,7 @@ how to produce valid json.
   |  { z }
   |  ^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  exclave_ { z }
   |             ^
@@ -226,7 +226,7 @@ how to produce valid json.
   |  exclave_ { z }
   |           ^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  let y = { z = x } in
   |                ^
@@ -234,7 +234,7 @@ how to produce valid json.
   |  let y = { z = x } in
   |          ^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  f { z };
   |      ^
@@ -242,7 +242,7 @@ how to produce valid json.
   |  f { z };
   |    ^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  f (local_ { z });
   |              ^
@@ -250,7 +250,7 @@ how to produce valid json.
   |  f (local_ { z });
   |    ^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  f { z }
   |      ^
@@ -258,7 +258,7 @@ how to produce valid json.
   |  f { z }
   |    ^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let g z = f { z } [@nontail]
   |              ^
@@ -266,7 +266,7 @@ how to produce valid json.
   |let g z = f { z } [@nontail]
   |            ^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  { z }
   |    ^
@@ -294,7 +294,7 @@ how to produce valid json.
   |  fun x -> g x
   |  ^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  exclave_ fun x -> g x
   |                  ^
@@ -302,7 +302,7 @@ how to produce valid json.
   |  exclave_ fun x -> g x
   |           ^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |let f g = (fun x -> g x)
   |                       ^
@@ -310,7 +310,7 @@ how to produce valid json.
   |let f g = (fun x -> g x)
   |          ^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  fun x -> x
   |         ^
@@ -318,7 +318,7 @@ how to produce valid json.
   |  fun x -> x
   |  ^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  function | x -> x
   |         ^
@@ -326,15 +326,7 @@ how to produce valid json.
   |  function | x -> x
   |  ^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
-  
-  |  exclave_ function | x -> x
-  |                  ^
-  
-  |  exclave_ function | x -> x
-  |                  ^
-  
-  "no relevant allocation to show"
+  "heap"
   
   |let f = (function | x -> x)
   |                          ^
@@ -342,7 +334,7 @@ how to produce valid json.
   |let f = (function | x -> x)
   |        ^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  function | x -> g x
   |         ^
@@ -352,7 +344,7 @@ how to produce valid json.
   |  function | x -> g x
   |^^^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f g x y =
   |          ^
@@ -364,7 +356,7 @@ how to produce valid json.
   |  exclave_ Some (g z)
   |^^^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |  let z = x + y in
   |            ^
@@ -408,7 +400,7 @@ how to produce valid json.
   |let f t1 t2 = { t1 with b = t2.b }
   |              ^^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f (t : floats_t) = t.a
   |                        ^
@@ -416,7 +408,7 @@ how to produce valid json.
   |let f (t : floats_t) = t.a
   |                       ^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f (t : floats_t) = exclave_ t.a
   |                                 ^
@@ -424,7 +416,7 @@ how to produce valid json.
   |let f (t : floats_t) = exclave_ t.a
   |                                ^^^
   
-  "could be stack or heap"
+  "stack"
   
 
 (VI) Arrays
@@ -436,7 +428,7 @@ how to produce valid json.
   |let x () = [| 1; 2; 3 |]
   |           ^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let x () = exclave_ [| 1; 2; 3 |]
   |                          ^
@@ -444,7 +436,7 @@ how to produce valid json.
   |let x () = exclave_ [| 1; 2; 3 |]
   |                    ^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
 
 (VII) Nested
@@ -456,7 +448,7 @@ how to produce valid json.
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                                 ^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                                       ^
@@ -464,7 +456,7 @@ how to produce valid json.
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                           ^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                                       ^
@@ -472,7 +464,7 @@ how to produce valid json.
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |let f x = exclave_ T { t = Not_t (Some x) }
   |                                       ^
@@ -485,7 +477,7 @@ how to produce valid json.
   |let f x = local_ (Some (Some x))
   |                       ^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |let f x = local_ (Some (Some x))
   |                             ^
@@ -493,7 +485,7 @@ how to produce valid json.
   |let f x = local_ (Some (Some x))
   |          ^^^^^^^^^^^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |let f x = local_ (Some (Some x))
   |                             ^
@@ -538,7 +530,7 @@ how to produce valid json.
   |let f () = { x = "OK" }
   |           ^^^^^^^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f x = A { a = x }
   |                  ^
@@ -554,7 +546,7 @@ how to produce valid json.
   |let f () = A "OK"
   |           ^^^^^^
   
-  "could be stack or heap"
+  "heap"
   
   |let f () = C "OK"
   |               ^
@@ -589,7 +581,7 @@ how to produce valid json.
   |  let t = { x = f x } in
   |          ^^^^^^^^^^^
   
-  "could be stack or heap"
+  "stack"
   
   |  let t = { x = f x } in
   |                  ^

--- a/tests/test-dirs/stack-or-heap.t/run.t
+++ b/tests/test-dirs/stack-or-heap.t/run.t
@@ -719,3 +719,11 @@ how to produce valid json.
   
   "heap"
   
+  |  let local_ z = Some x in
+  |                      ^
+  
+  |  let local_ z = Some x in
+  |      ^^^^^^^^^^^^^^^^^
+  
+  "stack"
+  

--- a/tests/test-dirs/stack-or-heap.t/unfinished.ml
+++ b/tests/test-dirs/stack-or-heap.t/unfinished.ml
@@ -1,4 +1,4 @@
-(* Snippets that don't fully compile *)
+(* Snippets in an unfinished file *)
 
 type t = { x : int ref }
 
@@ -29,16 +29,93 @@ let f (local_ x) =
 ;;
 
 let f x =
+  (* TODO: This test returns stack or heap, even though
+     we can confidently say that [Some y] is allocated
+     on the stack. *)
   let z = Some x in
             (* ^ *)
   5
 ;;
 
 let f x =
-  (* TODO: This test returns stack or heap, even though
-     we can confidently say that [Some y] is allocated
-     on the stack. *)
   let z = Some y in
             (* ^ *)
   z
 ;;
+
+let f (local_ x) y =
+  let z = [x, Some y] in
+                (* ^ *)
+;;
+
+let f x y =
+  let z = [x, Some y] in
+                (* ^ *)
+;;
+
+let f (local_ x) y =
+  let z = match Some 10 with
+    | Some _ -> [x; Some y]
+    | None -> [Some y]
+                 (* ^ *)
+  in
+;;
+
+let f x y =
+  let z = match Some 10 with
+    | Some _ -> [x; Some y]
+    | None -> [Some y]
+                 (* ^ *)
+  in
+;;
+
+let f x y =
+  let z = match Some 10 with
+    | Some _ -> [x; Some y]
+    | None -> [Some y]
+                 (* ^ *)
+  in
+  z
+;;
+
+let f (local_ x) y =
+  let z = in
+  [x; Some y]
+        (* ^ *)
+
+let f x y =
+  let z = in
+  exclave_ [x; Some y]
+                 (* ^ *)
+
+let _ =
+  let f x =
+    let z = Some x in
+              (* ^ *)
+    10
+  in
+  f 20
+;;
+
+let rec is_even x foo bar =
+  (* TODO: We can again confidently say that this
+     is stack, but we also need the mutually
+     recursive function's type to know this *)
+  let z = [foo; Some bar] in
+                  (* ^ *)
+  match x with
+  | 0 -> true
+  | _ -> not @@ is_odd (x - 1) foo bar
+
+and is_odd x foo bar =
+  match x with
+  | 0 -> false
+  | _ -> not @@ is_even (x - 1) foo bar
+
+let local_function x = 10
+let g x = 5 + local_function (Some x)
+                                (* ^ *)
+
+let global_function x = x
+let g x = global_function (Some x)
+                             (* ^ *)

--- a/tests/test-dirs/stack-or-heap.t/unfinished.ml
+++ b/tests/test-dirs/stack-or-heap.t/unfinished.ml
@@ -17,3 +17,25 @@ let g x =
                (* ^ *)
   let y =
 ;;
+
+let f x =
+  let z = Some x in
+            (* ^ *)
+;;
+
+let f (local_ x) =
+  let z = Some x in
+            (* ^ *)
+;;
+
+let f x =
+  let z = Some x in
+            (* ^ *)
+  5
+;;
+
+let f x =
+  let z = Some y in
+            (* ^ *)
+  z
+;;

--- a/tests/test-dirs/stack-or-heap.t/unfinished.ml
+++ b/tests/test-dirs/stack-or-heap.t/unfinished.ml
@@ -119,3 +119,8 @@ let g x = 5 + local_function (Some x)
 let global_function x = x
 let g x = global_function (Some x)
                              (* ^ *)
+
+let f x =
+  let local_ z = Some x in
+                   (* ^ *)
+;;

--- a/tests/test-dirs/stack-or-heap.t/unfinished.ml
+++ b/tests/test-dirs/stack-or-heap.t/unfinished.ml
@@ -35,6 +35,9 @@ let f x =
 ;;
 
 let f x =
+  (* TODO: This test returns stack or heap, even though
+     we can confidently say that [Some y] is allocated
+     on the stack. *)
   let z = Some y in
             (* ^ *)
   z


### PR DESCRIPTION
Make allocation analysis definitively state `stack` or `heap` if the program type checks. If it does not, Merlin will sometimes return `could be stack or heap`.