### PR TITLE
Backport #1709

### DIFF
--- a/src/ocaml/typing/typedecl.ml
+++ b/src/ocaml/typing/typedecl.ml
@@ -1955,7 +1955,9 @@ let transl_type_decl env rec_flag sdecl_list =
     (fun sdecl tdecl ->
       let decl = tdecl.typ_type in
        match Ctype.closed_type_decl decl with
-         Some ty -> raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
+         Some ty ->
+          if not (Msupport.erroneous_type_check ty) then
+            raise(Error(sdecl.ptype_loc, Unbound_type_var(ty,decl)))
        | None   -> ())
     sdecl_list tdecls;
   (* Check that constraints are enforced *)

--- a/src/ocaml/typing/typetexp.ml
+++ b/src/ocaml/typing/typetexp.ml
@@ -644,16 +644,11 @@ let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
        try
          transl_type_aux env ~policy ~aliased ~row_context mode styp
        with exn ->
-         let ty = new_global_var () in
+         let ty = new_global_var (Jkind.value ~why:(Unknown "merlin")) in
          Msupport.erroneous_type_register ty;
          Msupport.raise_error exn;
-<<<<<<< HEAD
            { ctyp_desc = Ttyp_var (None, None);
-             ctyp_type = new_global_var (Jkind.value ~why:(Unknown "merlin"));
-=======
-           { ctyp_desc = Ttyp_any;
              ctyp_type = ty;
->>>>>>> c05f3a35... Fix issue #1704 by correctly registering erroneous types
              ctyp_env = env;
              ctyp_loc = styp.ptyp_loc;
              ctyp_attributes = [];

--- a/src/ocaml/typing/typetexp.ml
+++ b/src/ocaml/typing/typetexp.ml
@@ -644,9 +644,16 @@ let rec transl_type env ~policy ?(aliased=false) ~row_context mode styp =
        try
          transl_type_aux env ~policy ~aliased ~row_context mode styp
        with exn ->
+         let ty = new_global_var () in
+         Msupport.erroneous_type_register ty;
          Msupport.raise_error exn;
+<<<<<<< HEAD
            { ctyp_desc = Ttyp_var (None, None);
              ctyp_type = new_global_var (Jkind.value ~why:(Unknown "merlin"));
+=======
+           { ctyp_desc = Ttyp_any;
+             ctyp_type = ty;
+>>>>>>> c05f3a35... Fix issue #1704 by correctly registering erroneous types
              ctyp_env = env;
              ctyp_loc = styp.ptyp_loc;
              ctyp_attributes = [];

--- a/tests/test-dirs/errors/issue1704-wrong-message.t
+++ b/tests/test-dirs/errors/issue1704-wrong-message.t
@@ -6,27 +6,12 @@
   > type foo3 = bar
   > EOF
 
-FIXME:Merlin should not report unbound variable errors in that case since it is
+Merlin should not report unbound variable errors in that case since it is
 due to it's own type recovery.
   $ $MERLIN single errors -filename test.ml <test.ml 
   {
     "class": "return",
     "value": [
-      {
-        "start": {
-          "line": 1,
-          "col": 0
-        },
-        "end": {
-          "line": 3,
-          "col": 1
-        },
-        "type": "typer",
-        "sub": [],
-        "valid": true,
-        "message": "A type variable is unbound in this type declaration.
-  In field bar: 'a the variable 'a is unbound"
-      },
       {
         "start": {
           "line": 2,
@@ -44,21 +29,6 @@ due to it's own type recovery.
       {
         "start": {
           "line": 4,
-          "col": 0
-        },
-        "end": {
-          "line": 4,
-          "col": 15
-        },
-        "type": "typer",
-        "sub": [],
-        "valid": true,
-        "message": "A type variable is unbound in this type declaration.
-  In type 'a the variable 'a is unbound"
-      },
-      {
-        "start": {
-          "line": 4,
           "col": 12
         },
         "end": {
@@ -69,21 +39,6 @@ due to it's own type recovery.
         "sub": [],
         "valid": true,
         "message": "Unbound module X"
-      },
-      {
-        "start": {
-          "line": 5,
-          "col": 0
-        },
-        "end": {
-          "line": 5,
-          "col": 15
-        },
-        "type": "typer",
-        "sub": [],
-        "valid": true,
-        "message": "A type variable is unbound in this type declaration.
-  In type 'a the variable 'a is unbound"
       },
       {
         "start": {

--- a/tests/test-dirs/errors/issue1704-wrong-message.t
+++ b/tests/test-dirs/errors/issue1704-wrong-message.t
@@ -1,0 +1,104 @@
+  $ cat >test.ml <<'EOF'
+  > type foo = {
+  >   bar: X.t;
+  > }
+  > type foo2 = X.t
+  > type foo3 = bar
+  > EOF
+
+FIXME:Merlin should not report unbound variable errors in that case since it is
+due to it's own type recovery.
+  $ $MERLIN single errors -filename test.ml <test.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 3,
+          "col": 1
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "A type variable is unbound in this type declaration.
+  In field bar: 'a the variable 'a is unbound"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 10
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module X"
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 0
+        },
+        "end": {
+          "line": 4,
+          "col": 15
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "A type variable is unbound in this type declaration.
+  In type 'a the variable 'a is unbound"
+      },
+      {
+        "start": {
+          "line": 4,
+          "col": 12
+        },
+        "end": {
+          "line": 4,
+          "col": 15
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound module X"
+      },
+      {
+        "start": {
+          "line": 5,
+          "col": 0
+        },
+        "end": {
+          "line": 5,
+          "col": 15
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "A type variable is unbound in this type declaration.
+  In type 'a the variable 'a is unbound"
+      },
+      {
+        "start": {
+          "line": 5,
+          "col": 12
+        },
+        "end": {
+          "line": 5,
+          "col": 15
+        },
+        "type": "typer",
+        "sub": [],
+        "valid": true,
+        "message": "Unbound type constructor bar"
+      }
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Backport ocaml/merlin#1709 to fix misleading type errors like this:

```ocaml
type t = {
    foo : int
    bar : baz
}

(*
A type variable is unbound in this type declaration.
In field foo: 'a the variable 'a is unbound
*)
```

@liam923 please merge once you review this.