### PR TITLE
Add `-gno-upstream-dwarf` to list of ignored flags

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -540,6 +540,7 @@ let ocaml_ignored_flags = [
   "-gno-dwarf-inlined-frames";
   "-cfg-stack-checks";
   "-no-cfg-stack-checks";
+  "-gno-upstream-dwarf";
 ]
 
 let ocaml_ignored_parametrized_flags = [


### PR DESCRIPTION
The `-gno-upstream-dwarf` is not in the list of flags ignored by Merlin, despite having been in the compiler for the past couple years. I'm surprised this hasn't led to other Merlin issues.