### PR TITLE
Backport 1706

### DIFF
--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -1,0 +1,230 @@
+open Browse_raw
+
+type syntax_info = Query_protocol.syntax_doc_result option
+
+let syntax_doc_url endpoint =
+  let base_url = "https://v2.ocaml.org/releases/4.14/htmlman/" in
+  base_url ^ endpoint
+
+let get_syntax_doc cursor_loc node : syntax_info =
+  match node with
+  | (_, Type_kind _)
+    :: (_, Type_declaration _)
+    :: (_, With_constraint (Twith_typesubst _))
+    :: _ ->
+      Some
+        {
+          name = "Destructive substitution";
+          description =
+            "Behaves like normal signature constraints but removes the \
+             redefined type or module from the signature.";
+          documentation =
+            syntax_doc_url
+              "signaturesubstitution.html#ss:destructive-substitution";
+        }
+  | (_, Type_kind _)
+    :: (_, Type_declaration _)
+    :: (_, Signature_item ({ sig_desc = Tsig_typesubst _; _ }, _))
+    :: _ ->
+      Some
+        {
+          name = "Local substitution";
+          description =
+            "Behaves like destructive substitution but is introduced during \
+             the specification of the signature, and will apply to all the \
+             items that follow.";
+          documentation =
+            syntax_doc_url "signaturesubstitution.html#ss:local-substitution";
+        }
+  | (_, Module_type _)
+    :: (_, Module_type _)
+    :: ( _,
+         Module_type_constraint
+           (Tmodtype_explicit
+             { mty_desc = Tmty_with (_, [ (_, _, Twith_modtype _) ]); _ }) )
+    :: _ ->
+      Some
+        {
+          name = "Module substitution";
+          description =
+            "Behaves like type substitutions but are useful to refine an \
+             abstract module type in a signature into a concrete module type,";
+          documentation =
+            syntax_doc_url
+              "signaturesubstitution.html#ss:module-type-substitution";
+        }
+  | (_, Type_kind Ttype_open) :: (_, Type_declaration { typ_private; _ }) :: _
+    ->
+      let e_name = "Extensible Variant Type" in
+      let e_description =
+        "Can be extended with new variant constructors using `+=`."
+      in
+      let e_url = "extensiblevariants.html" in
+      let name, description, url =
+        match typ_private with
+        | Public -> (e_name, e_description, e_url)
+        | Private ->
+            ( Format.sprintf "Private %s" e_name,
+              Format.sprintf
+                "%s. Prevents new constructors from being declared directly, \
+                 but allows extension constructors to be referred to in \
+                 interfaces."
+                e_description,
+              "extensiblevariants.html#ss:private-extensible" )
+      in
+      Some { name; description; documentation = syntax_doc_url url }
+  | (_, Constructor_declaration _)
+    :: (_, Type_kind (Ttype_variant _))
+    :: (_, Type_declaration { typ_private; _ })
+    :: _
+  | _
+    :: (_, Constructor_declaration _)
+    :: (_, Type_kind (Ttype_variant _))
+    :: (_, Type_declaration { typ_private; _ })
+    :: _ ->
+      let v_name = "Variant Type" in
+      let v_description =
+        "Represent's data that may take on multiple different forms."
+      in
+      let v_url = "typedecl.html#ss:typedefs" in
+      let name, description, url =
+        match typ_private with
+        | Public -> (v_name, v_description, v_url)
+        | Private ->
+            ( Format.sprintf "Private %s" v_name,
+              Format.sprintf
+                "%s This type is private, values cannot be constructed \
+                 directly but can be de-structured as usual."
+                v_description,
+              "privatetypes.html#ss:private-types-variant" )
+      in
+      Some { name; description; documentation = syntax_doc_url url }
+  | (_, Core_type _)
+    :: (_, Core_type _)
+    :: (_, Label_declaration _)
+    :: (_, Type_kind (Ttype_record _))
+    :: (_, Type_declaration { typ_private; _ })
+    :: _ ->
+      let r_name = "Record Type" in
+      let r_description = "Defines variants with a fixed set of fields" in
+      let r_url = "typedecl.html#ss:typedefs" in
+      let name, description, url =
+        match typ_private with
+        | Public -> (r_name, r_description, r_url)
+        | Private ->
+            ( Format.sprintf "Private %s" r_name,
+              Format.sprintf
+                "%s This type is private, values cannot be constructed \
+                 directly but can be de-structured as usual."
+                r_description,
+              "privatetypes.html#ss:private-types-variant" )
+      in
+      Some { name; description; documentation = syntax_doc_url url }
+  | (_, Type_kind (Ttype_variant _))
+    :: (_, Type_declaration { typ_private = Public; _ })
+    :: _ ->
+      Some
+        {
+          name = "Empty Variant Type";
+          description = "An empty variant type.";
+          documentation = syntax_doc_url "emptyvariants.html";
+        }
+  | (_, Type_kind Ttype_abstract)
+    :: (_, Type_declaration { typ_private = Public; typ_manifest = None; _ })
+    :: _ ->
+      Some
+        {
+          name = "Abstract Type";
+          description =
+            "Define variants with arbitrary data structures, including other \
+             variants, records, and functions";
+          documentation = syntax_doc_url "typedecl.html#ss:typedefs";
+        }
+  | (_, Type_kind Ttype_abstract)
+    :: (_, Type_declaration { typ_private = Private; _ })
+    :: _ ->
+      Some
+        {
+          name = "Private Type Abbreviation";
+          description =
+            "Declares a type that is distinct from its implementation type \
+             `typexpr`.";
+          documentation =
+            syntax_doc_url "privatetypes.html#ss:private-types-abbrev";
+        }
+  | (_, Expression _)
+    :: (_, Expression _)
+    :: (_, Value_binding _)
+    :: (_, Structure_item ({ str_desc = Tstr_value (Recursive, _); _ }, _))
+    :: _ ->
+      Some
+        {
+          name = "Recursive value definition";
+          description =
+            "Supports a certain class of recursive definitions of \
+             non-functional values.";
+          documentation = syntax_doc_url "letrecvalues.html";
+        }
+  | (_, Module_expr _) :: (_, Module_type { mty_desc = Tmty_typeof _; _ }) :: _
+    ->
+      Some
+        {
+          name = "Recovering module type";
+          description =
+            "Expands to the module type (signature or functor type) inferred \
+             for the module expression `module-expr`. ";
+          documentation = syntax_doc_url "moduletypeof.html";
+        }
+  | (_, Module_expr _)
+    :: (_, Module_expr _)
+    :: (_, Module_binding _)
+    :: (_, Structure_item ({ str_desc = Tstr_recmodule _; _ }, _))
+    :: _ ->
+      Some
+        {
+          name = "Recursive module";
+          description =
+            "A simultaneous definition of modules that can refer recursively \
+             to each others.";
+          documentation = syntax_doc_url "recursivemodules.html";
+        }
+  | (_, Expression _)
+    :: (_, Expression _)
+    :: (_, Case _)
+    :: (_, Expression _)
+    :: ( _,
+         Value_binding
+           {
+             vb_expr =
+               { exp_extra = [ (Texp_newtype' (_, loc), _, _) ]; exp_loc; _ };
+             _;
+           } )
+    :: _ -> (
+      let in_range =
+        cursor_loc.Lexing.pos_cnum - 1 > exp_loc.loc_start.pos_cnum
+        && cursor_loc.Lexing.pos_cnum <= loc.loc.loc_end.pos_cnum + 1
+      in
+      match in_range with
+      | true ->
+          Some
+            {
+              name = "Locally Abstract Type";
+              description =
+                "Type constructor which is considered abstract in the scope of \
+                 the sub-expression and replaced by a fresh type variable.";
+              documentation = syntax_doc_url "locallyabstract.html";
+            }
+      | false -> None)
+  | (_, Module_expr _)
+    :: (_, Module_expr _)
+    :: (_, Expression { exp_desc = Texp_pack _; _ })
+    :: _ ->
+      Some
+        {
+          name = "First class module";
+          description =
+            "Converts a module (structure or functor) to a value of the core \
+             language that encapsulates the module.";
+          documentation = syntax_doc_url "firstclassmodules.html";
+        }
+  | _ -> None

--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -196,7 +196,7 @@ let get_syntax_doc cursor_loc node : syntax_info =
          Value_binding
            {
              vb_expr =
-               { exp_extra = [ (Texp_newtype' (_, loc), _, _) ]; exp_loc; _ };
+               { exp_extra = [ (Texp_newtype' (_, loc, _, _), _, _) ]; exp_loc; _ };
              _;
            } )
     :: _ -> (

--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -190,7 +190,6 @@ let get_syntax_doc cursor_loc node : syntax_info =
         }
   | (_, Expression _)
     :: (_, Expression _)
-    :: (_, Case _)
     :: (_, Expression _)
     :: ( _,
          Value_binding

--- a/src/analysis/syntax_doc.mli
+++ b/src/analysis/syntax_doc.mli
@@ -1,0 +1,1 @@
+val get_syntax_doc: Lexing.position -> (Env.t * Browse_raw.node) list -> Query_protocol.syntax_doc_result option

--- a/src/frontend/ocamlmerlin/new/new_commands.ml
+++ b/src/frontend/ocamlmerlin/new/new_commands.ml
@@ -199,6 +199,21 @@ Otherwise, Merlin looks for the documentation for the entity under the cursor (a
     end
   ;
 
+  command "syntax-document"
+    ~doc: "Returns documentation for OCaml syntax for the entity under the cursor"
+    ~spec: [
+      arg "-position" "<position> Position to complete"
+          (marg_position (fun pos _pos -> pos));
+    ]
+    ~default: `None
+    begin fun buffer pos ->
+      match pos with 
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> 
+        run buffer (Query_protocol.Syntax_document pos)
+    end
+  ;
+
   command "enclosing"
     ~spec: [
       arg "-position" "<position> Position to complete"

--- a/src/frontend/ocamlmerlin/query_json.ml
+++ b/src/frontend/ocamlmerlin/query_json.ml
@@ -121,6 +121,8 @@ let dump (type a) : a t -> json =
         );
       "position", mk_position pos;
     ]
+  | Syntax_document pos ->
+    mk "syntax-document" [ ("position", mk_position pos) ]
   | Locate (prefix, look_for, pos) ->
     mk "locate" [
       "prefix", (match prefix with
@@ -398,6 +400,16 @@ let json_of_response (type a) (query : a t) (response : a) : json =
       | `Found doc ->
         `String doc
     end
+  | Syntax_document _, resp -> 
+    (match resp with
+    | `Found info ->
+      `Assoc
+      [
+        ("name", `String info.name);
+        ("description", `String info.description);
+        ("url", `String info.documentation);
+      ]
+    | `No_documentation -> `String "No documentation found")
   | Locate_type _, resp -> json_of_locate resp
   | Locate _, resp -> json_of_locate resp
   | Jump _, resp ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -579,6 +579,15 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a =
       Locate.get_doc ~config
         ~env ~local_defs ~comments ~pos (`User_input path)
 
+  | Syntax_document pos ->
+    let typer = Mpipeline.typer_result pipeline in
+    let pos = Mpipeline.get_lexing_pos pipeline pos in
+    let node = Mtyper.node_at typer pos in
+    let res = Syntax_doc.get_syntax_doc pos node in 
+    (match res with
+    | Some res -> `Found res 
+    | None -> `No_documentation)
+
   | Locate (patho, ml_or_mli, pos) ->
     let typer = Mpipeline.typer_result pipeline in
     let local_defs = Mtyper.get_typedtree typer in

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -96,6 +96,13 @@ type error_filter = {
   typing : bool;
 }
 
+type syntax_doc_result = 
+{ 
+    name : string; 
+    description : string; 
+    documentation : string 
+}
+
 type is_tail_position = [`No | `Tail_position | `Tail_call]
 
 type _ _bool = bool
@@ -134,6 +141,11 @@ type _ t =
        | `Not_in_env of string
        | `File_not_found of string
        | `Not_found of string * string option
+       | `No_documentation
+       ] t
+  | Syntax_document
+    : Msource.position
+    -> [ `Found of syntax_doc_result
        | `No_documentation
        ] t
   | Locate_type

--- a/tests/test-dirs/syntax-document/language-extensions.t/run.t
+++ b/tests/test-dirs/syntax-document/language-extensions.t/run.t
@@ -1,0 +1,275 @@
+Syntax-Documentation Test - Language-extentions
+  $ alias syn_doc="$MERLIN single syntax-document -position "
+
+Recursive definition of values
+  $ cat > main.ml << EOF
+  > let rec name1 = 1 :: name2 and name2 = 2 :: name1
+  > EOF
+
+on rec
+  $ syn_doc 1:6 \
+  > -filename ./main.ml < ./main.ml | jq '.value.name'
+  "Recursive value definition"
+
+Recursive modules
+  $ cat > rec-modules.ml << EOF
+  > module rec A : sig
+  >   type t = Leaf of string | Node of ASet.t
+  >   val compare: t -> t -> int
+  > end = struct
+  > type t = Leaf of string | Node of ASet.t
+  > let compare t1 t2 =
+  >   match (t1, t2) with
+  >    | (Leaf s1, Leaf s2) -> Stdlib.compare s1 s2
+  >    | (Leaf _, Node _) -> 1
+  >    | (Node _, Leaf _) -> -1
+  >    | (Node n1, Node n2) -> ASet.compare n1 n2
+  > end
+  > and ASet : Set.S with type elt = A.t
+  > = Set.Make(A)
+  > module B = struct
+  >    module rec A : sig
+  >      type t
+  >      val empty: t
+  >    end = struct
+  >      type t = Empty | Node of int * t * t
+  >      let empty = Empty
+  >    end
+  >  end
+  > EOF
+on rec
+  $ syn_doc 1:9 \
+  > -filename ./rec-modules.ml < ./rec-modules.ml | jq '.value.name'
+  "Recursive module"
+On type t = Leaf of stri...
+  $ syn_doc 5:5 \
+  > -filename ./rec-modules.ml < ./rec-modules.ml | jq '.value.name'
+  "Variant Type"
+On rec .. Nested recurvise module
+  $ syn_doc 16:12 \
+  > -filename ./rec-modules.ml < ./rec-modules.ml | jq '.value.name'
+  "Recursive module"
+
+
+Recovering the type of a module
+  $ cat > rec-mod-type.ml << EOF 
+  > module type MYHASH = sig
+  >   include module type of struct include Hashtbl end
+  >   val replace: ('a, 'b) t -> 'a -> 'b -> unit
+  > end
+  > module MySet : module type of Set = struct
+  > end
+  > EOF
+on module type of..
+  $ syn_doc 2:23 \
+  > -filename ./rec-mod-type.ml < ./rec-mod-type.ml | jq '.value.name'
+  "Recovering module type"
+on module type of..
+  $ syn_doc 5:28 \
+  > -filename ./rec-mod-type.ml < ./rec-mod-type.ml | jq '.value.name'
+  "Recovering module type"
+
+
+// Signature Substitutions
+  $ cat > sig-subs.ml << EOF
+  > module type Printable = sig
+  >    type t
+  >    val print : Format.formatter -> t -> unit
+  >  end
+  >  module type Comparable = sig
+  >    type t
+  >    val compare : t -> t -> int
+  >  end
+  >  module type PrintableComparable = sig
+  >    include Printable
+  >    include Comparable with type t := t
+  >  end
+  >  module type S = sig
+  >    type t
+  >    module Sub : sig
+  >      type outer := t
+  >      type t
+  >      val to_outer : t -> outer
+  >    end
+  >  end
+  >  module type ENDO = sig
+  >    module type T
+  >    module F: T -> T
+  >  end
+  > module Endo(X: sig module type T end): ENDO with module type T = X.T =
+  >  struct
+  >      module type T = X.T
+  >      module F(X:T) = X
+  >  end
+  > EOF
+// Destructive substitutions
+On 'with':
+  $ syn_doc 11:24 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value'
+  "No documentation found"
+
+On 'type t :='
+  $ syn_doc 11:27 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Destructive substitution"
+  $ syn_doc 11:32 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Destructive substitution"
+  $ syn_doc 11:34 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Destructive substitution"
+On '... t'
+  $ syn_doc 11:37 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value'
+  "No documentation found"
+On type t
+  $ syn_doc 2:9 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Abstract Type"
+// Local substitutions
+  $ syn_doc 16:12 -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Local substitution"
+// Module type substitutions
+  $ syn_doc 25:57 \
+  > -filename ./sig-subs.ml < ./sig-subs.ml | jq '.value.name'
+  "Module substitution"
+
+
+// Types
+  $ cat > types.ml << EOF 
+  > type a1 = ..
+  > type a2 = A
+  > type a3 = |
+  > type a4 = {x: int}
+  > type a5 = int
+  > EOF
+on type a1..
+  $ syn_doc 1:5 \
+  > -filename ./types.ml < ./types.ml | jq '.value.name'
+  "Extensible Variant Type"
+on type a2..
+  $ syn_doc 2:5 \
+  > -filename ./types.ml < ./types.ml | jq '.value.name'
+  "Variant Type"
+on type a3..
+  $ syn_doc 3:6 \
+  > -filename ./types.ml < ./types.ml | jq '.value.name'
+  "Empty Variant Type"
+on type a4..
+  $ syn_doc 4:5 \
+  > -filename ./types.ml < ./types.ml | jq '.value.name'
+  "Record Type"
+on type a5..
+  $ syn_doc 5:5 \
+  > -filename ./types.ml < ./types.ml | jq '.value'
+  "No documentation found"
+
+// Private types
+// Extensible
+  $ cat > p-types.ml << EOF
+  > type b1 = private ..
+  > type b2 = private A
+  > type b3 = private A of int
+  > type b4 = private { x:int }
+  > type b5 = private int 
+  > module N : sig
+  >   type t = private int
+  >   val of_int: int -> t
+  >   val to_int: t -> int
+  > end = struct
+  >   type t = int
+  >   let of_int n = assert (n >= 0); n
+  >   let to_int n = n
+  > end
+  > EOF
+on type b1..
+  $ syn_doc 1:14 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Extensible Variant Type"
+on type b2..
+  $ syn_doc 2:14 \
+  > -filename ./private-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Variant Type"
+on type b3..
+  $ syn_doc 3:14 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Variant Type"
+on type b4..
+  $ syn_doc 4:14 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Record Type"
+on b5..
+  $ syn_doc 5:14 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Type Abbreviation"
+on type t = private int..
+  $ syn_doc 7:14 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value.name'
+  "Private Type Abbreviation"
+on type t = int..
+  $ syn_doc 11:7 \
+  > -filename ./p-types.ml < ./p-types.ml | jq '.value'
+  "No documentation found"
+
+// Locally abstract data types
+  $ cat > locally-abstract-dt.ml << EOF 
+  > let f = fun (type t) (x: t) -> x = x
+  > let sort_uniq (type s) (cmp : s -> s -> int) =
+  >   let module S = Set.Make(struct type t = s let compare = cmp end) in
+  >   fun l ->
+  >     S.elements (List.fold_right S.add l S.empty)
+  > EOF
+// Locally abstract data types
+on type t..
+  $ syn_doc 1:17 \
+  > -filename ./locally-abstract-dt.ml < ./locally-abstract-dt.ml | jq '.value.name'
+  "Locally Abstract Type"
+On fun..
+  $ syn_doc 1:9 \
+  > -filename ./locally-abstract-dt.ml < ./locally-abstract-dt.ml | jq '.value'
+  "No documentation found"
+On x
+  $ syn_doc 1:39 \
+  > -filename ./locally-abstract-dt.ml < ./locally-abstract-dt.ml | jq '.value'
+  "No documentation found"
+
+
+// First class Modules
+  $ cat > first-class-modules.ml << EOF
+  > type picture = { x : int; y : int }
+  > module type DEVICE = sig
+  >   val draw : picture -> unit
+  > end
+  > let devices : (string, (module DEVICE)) Hashtbl.t = Hashtbl.create 17
+  > module SVG = struct end
+  > module PNG = struct end
+  > let _svg = Hashtbl.add devices "SVG" (module SVG : DEVICE)
+  > let _png = Hashtbl.add devices "PNG" (module PNG : SVG)
+  > let sort (type s) (module Set : Set.S with type elt = s) l =
+  >   Set.elements (List.fold_right Set.add l Set.empty)
+  > let make_set (type s) cmp =
+  >   let module S = Set.Make(struct
+  >     type t = s
+  >     let compare = cmp
+  >   end) in
+  >   (module S : Set.S with type elt = s)
+  > EOF
+on type picture
+  $ syn_doc 1:6 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value.name'
+  "Record Type"
+on module SVG..
+  $ syn_doc 6:6 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value'
+  "No documentation found"
+on (module SVG : DEVICE)
+  $ syn_doc 8:43 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value.name'
+  "First class module"
+on (module PNG : SVG)
+  $ syn_doc 9:43 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value'
+  "No documentation found"
+on type t = s..
+  $ syn_doc 14:10 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value'
+  "No documentation found"
+on (module S : Set.S with type elt = s)
+  $ syn_doc 17:2 \
+  > -filename ./first-class-modules.ml < ./first-class-modules.ml | jq '.value.name'
+  "First class module"
+


### PR DESCRIPTION
Backport [upstream PR 1706](https://github.com/ocaml/merlin/pull/1706), which adds the `syntax-document` command