### PR TITLE
Backport `UNIT_NAME` and `WRAPPING_PREFIX` directives

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -100,6 +100,8 @@ module Cache = File_cache.Make (struct
             tell (`STDLIB (String.drop 7 line))
           else if String.is_prefixed ~by:"UNIT_NAME " line then
             tell (`UNIT_NAME (String.drop 10 line))
+          else if String.is_prefixed ~by:"WRAPPING_PREFIX " line then
+            tell (`WRAPPING_PREFIX (String.drop 16 line))
           else if String.is_prefixed ~by:"FINDLIB " line then
             tell (`FINDLIB (String.drop 8 line))
           else if String.is_prefixed ~by:"SUFFIX " line then
@@ -313,7 +315,6 @@ type config = {
   pass_forward : Merlin_dot_protocol.Directive.no_processing_required list;
   to_canonicalize : (string * Merlin_dot_protocol.Directive.include_path) list;
   stdlib : string option;
-  unit_name   : string option;
   packages_to_load : string list;
   findlib : string option;
   findlib_path : string list;
@@ -324,7 +325,6 @@ let empty_config = {
   pass_forward      = [];
   to_canonicalize   = [];
   stdlib            = None;
-  unit_name         = None;
   packages_to_load  = [];
   findlib           = None;
   findlib_path      = [];
@@ -337,7 +337,11 @@ let prepend_config ~cwd ~cfg =
     | `B _ | `S _ | `BH _ | `SH _ | `CMI _ | `CMT _ | `INDEX _ as directive ->
       { cfg with to_canonicalize = (cwd, directive) :: cfg.to_canonicalize }
     | `EXT _ | `SUFFIX _ | `FLG _ | `READER _
-    | (`EXCLUDE_QUERY_DIR | `USE_PPX_CACHE | `UNKNOWN_TAG _) as directive ->
+    | (`EXCLUDE_QUERY_DIR
+      | `USE_PPX_CACHE
+      | `UNIT_NAME _
+      | `WRAPPING_PREFIX _
+      | `UNKNOWN_TAG _) as directive ->
       { cfg with pass_forward = directive :: cfg.pass_forward }
     | `PKG ps ->
       { cfg with packages_to_load = ps @ cfg.packages_to_load }
@@ -349,8 +353,6 @@ let prepend_config ~cwd ~cfg =
         log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
       end;
       { cfg with stdlib = Some canon_path }
-    | `UNIT_NAME name ->
-      { cfg with unit_name = Some name }
     | `FINDLIB path ->
       let canon_path = canonicalize_filename ~cwd path in
       begin match cfg.stdlib with

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -98,6 +98,8 @@ module Cache = File_cache.Make (struct
             includes := String.trim (String.drop 2 line) :: !includes
           else if String.is_prefixed ~by:"STDLIB " line then
             tell (`STDLIB (String.drop 7 line))
+          else if String.is_prefixed ~by:"UNIT_NAME " line then
+            tell (`UNIT_NAME (String.drop 10 line))
           else if String.is_prefixed ~by:"FINDLIB " line then
             tell (`FINDLIB (String.drop 8 line))
           else if String.is_prefixed ~by:"SUFFIX " line then
@@ -311,6 +313,7 @@ type config = {
   pass_forward : Merlin_dot_protocol.Directive.no_processing_required list;
   to_canonicalize : (string * Merlin_dot_protocol.Directive.include_path) list;
   stdlib : string option;
+  unit_name   : string option;
   packages_to_load : string list;
   findlib : string option;
   findlib_path : string list;
@@ -321,6 +324,7 @@ let empty_config = {
   pass_forward      = [];
   to_canonicalize   = [];
   stdlib            = None;
+  unit_name         = None;
   packages_to_load  = [];
   findlib           = None;
   findlib_path      = [];
@@ -345,6 +349,8 @@ let prepend_config ~cwd ~cfg =
         log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
       end;
       { cfg with stdlib = Some canon_path }
+    | `UNIT_NAME name ->
+      { cfg with unit_name = Some name }
     | `FINDLIB path ->
       let canon_path = canonicalize_filename ~cwd path in
       begin match cfg.stdlib with

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -44,6 +44,7 @@ module Directive = struct
     | `FLG of string list
     | `STDLIB of string
     | `UNIT_NAME of string
+    | `WRAPPING_PREFIX of string
     | `SUFFIX of string
     | `READER of string list
     | `EXCLUDE_QUERY_DIR
@@ -96,6 +97,7 @@ module Sexp = struct
         | "INDEX" -> `INDEX value
         | "STDLIB" -> `STDLIB value
         | "UNIT_NAME" -> `UNIT_NAME value
+        | "WRAPPING_PREFIX" -> `WRAPPING_PREFIX value
         | "SUFFIX" -> `SUFFIX value
         | "ERROR" -> `ERROR_MSG value
         | "FLG" ->
@@ -129,6 +131,7 @@ module Sexp = struct
         | `CMT s -> ("CMT", single s)
         | `INDEX s -> ("INDEX", single s)
         | `UNIT_NAME s -> ("UNIT_NAME", single s)
+        | `WRAPPING_PREFIX s -> ("WRAPPING_PREFIX", single s)
         | `EXT ss -> ("EXT", [ List (atoms_of_strings ss) ])
         | `FLG ss -> ("FLG", [ List (atoms_of_strings ss) ])
         | `STDLIB s -> ("STDLIB", single s)

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -43,6 +43,7 @@ module Directive = struct
     [ `EXT of string list
     | `FLG of string list
     | `STDLIB of string
+    | `UNIT_NAME of string
     | `SUFFIX of string
     | `READER of string list
     | `EXCLUDE_QUERY_DIR
@@ -94,6 +95,7 @@ module Sexp = struct
         | "CMT" -> `CMT value
         | "INDEX" -> `INDEX value
         | "STDLIB" -> `STDLIB value
+        | "UNIT_NAME" -> `UNIT_NAME value
         | "SUFFIX" -> `SUFFIX value
         | "ERROR" -> `ERROR_MSG value
         | "FLG" ->
@@ -126,6 +128,7 @@ module Sexp = struct
         | `CMI s -> ("CMI", single s)
         | `CMT s -> ("CMT", single s)
         | `INDEX s -> ("INDEX", single s)
+        | `UNIT_NAME s -> ("UNIT_NAME", single s)
         | `EXT ss -> ("EXT", [ List (atoms_of_strings ss) ])
         | `FLG ss -> ("FLG", [ List (atoms_of_strings ss) ])
         | `STDLIB s -> ("STDLIB", single s)

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -55,6 +55,7 @@ module Directive : sig
     [ `EXT of string list
     | `FLG of string list
     | `STDLIB of string
+    | `UNIT_NAME of string
     | `SUFFIX of string
     | `READER of string list
     | `EXCLUDE_QUERY_DIR

--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -56,6 +56,7 @@ module Directive : sig
     | `FLG of string list
     | `STDLIB of string
     | `UNIT_NAME of string
+    | `WRAPPING_PREFIX of string
     | `SUFFIX of string
     | `READER of string list
     | `EXCLUDE_QUERY_DIR

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -86,6 +86,7 @@ type merlin = {
   extensions  : string list;
   suffixes    : (string * string) list;
   stdlib      : string option;
+  unit_name   : string option;
   reader      : string list;
   protocol    : [`Json | `Sexp];
   log_file    : string option;
@@ -126,6 +127,7 @@ let dump_merlin x =
         ]) x.suffixes
     );
     "stdlib"       , Json.option Json.string x.stdlib;
+    "unit_name"    , Json.option Json.string x.unit_name;
     "reader"       , `List (List.map ~f:Json.string x.reader);
     "protocol"     , (match x.protocol with
         | `Json -> `String "json"
@@ -264,6 +266,7 @@ let get_external_config path t =
       extensions = dot.extensions @ merlin.extensions;
       suffixes = dot.suffixes @ merlin.suffixes;
       stdlib = (if dot.stdlib = None then merlin.stdlib else dot.stdlib);
+      unit_name = (if dot.unit_name = None then merlin.unit_name else dot.unit_name);
       reader =
         if dot.reader = []
         then merlin.reader
@@ -802,6 +805,7 @@ let initial = {
     extensions  = [];
     suffixes    = [(".ml", ".mli"); (".re", ".rei")];
     stdlib      = None;
+    unit_name   = None;
     reader      = [];
     protocol    = `Json;
     log_file    = None;
@@ -979,4 +983,7 @@ let global_modules ?(include_current=false) config = (
 
 let filename t = t.query.filename
 
-let unitname t = Misc.unitname t.query.filename
+let unitname t =
+  match t.merlin.unit_name with
+  | Some name -> Misc.unitname name
+  | None -> Misc.unitname t.query.filename

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -42,6 +42,7 @@ type merlin = {
   suffixes    : (string * string) list;
   stdlib      : string option;
   unit_name   : string option;
+  wrapping_prefix : string option;
   reader      : string list;
   protocol    : [`Json | `Sexp];
   log_file    : string option;

--- a/src/kernel/mconfig.mli
+++ b/src/kernel/mconfig.mli
@@ -41,6 +41,7 @@ type merlin = {
   extensions  : string list;
   suffixes    : (string * string) list;
   stdlib      : string option;
+  unit_name   : string option;
   reader      : string list;
   protocol    : [`Json | `Sexp];
   log_file    : string option;

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -44,6 +44,7 @@ type config = {
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;
+  unit_name    : string option;
   reader       : string list;
   exclude_query_dir : bool;
   use_ppx_cache : bool;
@@ -61,6 +62,7 @@ let empty_config = {
   suffixes     = [];
   flags        = [];
   stdlib       = None;
+  unit_name    = None;
   reader       = [];
   exclude_query_dir = false;
   use_ppx_cache = false;
@@ -256,6 +258,8 @@ let prepend_config ~dir:cwd configurator (directives : directive list) config =
       {config with flags = flags :: config.flags}, errors
     | `STDLIB path ->
       {config with stdlib = Some path}, errors
+    | `UNIT_NAME name ->
+      {config with unit_name = Some name}, errors
     | `READER reader ->
       {config with reader}, errors
     | `EXCLUDE_QUERY_DIR ->
@@ -287,6 +291,7 @@ let postprocess_config config =
     suffixes     = clean config.suffixes;
     flags        = clean config.flags;
     stdlib      = config.stdlib;
+    unit_name   = config.unit_name;
     reader      = config.reader;
     exclude_query_dir = config.exclude_query_dir;
     use_ppx_cache = config.use_ppx_cache;

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -45,6 +45,7 @@ type config = {
   suffixes     : (string * string) list;
   stdlib       : string option;
   unit_name    : string option;
+  wrapping_prefix : string option;
   reader       : string list;
   exclude_query_dir : bool;
   use_ppx_cache : bool;
@@ -63,6 +64,7 @@ let empty_config = {
   flags        = [];
   stdlib       = None;
   unit_name    = None;
+  wrapping_prefix = None;
   reader       = [];
   exclude_query_dir = false;
   use_ppx_cache = false;
@@ -260,6 +262,8 @@ let prepend_config ~dir:cwd configurator (directives : directive list) config =
       {config with stdlib = Some path}, errors
     | `UNIT_NAME name ->
       {config with unit_name = Some name}, errors
+    | `WRAPPING_PREFIX prefix ->
+      {config with wrapping_prefix = Some prefix}, errors
     | `READER reader ->
       {config with reader}, errors
     | `EXCLUDE_QUERY_DIR ->
@@ -292,6 +296,7 @@ let postprocess_config config =
     flags        = clean config.flags;
     stdlib      = config.stdlib;
     unit_name   = config.unit_name;
+    wrapping_prefix = config.wrapping_prefix;
     reader      = config.reader;
     exclude_query_dir = config.exclude_query_dir;
     use_ppx_cache = config.use_ppx_cache;

--- a/src/kernel/mconfig_dot.mli
+++ b/src/kernel/mconfig_dot.mli
@@ -40,6 +40,7 @@ type config = {
   extensions   : string list;
   suffixes     : (string * string) list;
   stdlib       : string option;
+  unit_name    : string option;
   reader       : string list;
   exclude_query_dir : bool;
   use_ppx_cache : bool;

--- a/src/kernel/mconfig_dot.mli
+++ b/src/kernel/mconfig_dot.mli
@@ -41,6 +41,7 @@ type config = {
   suffixes     : (string * string) list;
   stdlib       : string option;
   unit_name    : string option;
+  wrapping_prefix : string option;
   reader       : string list;
   exclude_query_dir : bool;
   use_ppx_cache : bool;

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -40,6 +40,7 @@
       }
     ],
     "stdlib": "lib/ocaml",
+    "unit_name": null,
     "reader": [],
     "protocol": "json",
     "log_file": null,

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -41,6 +41,7 @@
     ],
     "stdlib": "lib/ocaml",
     "unit_name": null,
+    "wrapping_prefix": null,
     "reader": [],
     "protocol": "json",
     "log_file": null,

--- a/tests/test-dirs/config/dot-merlin-reader/quoting.t
+++ b/tests/test-dirs/config/dot-merlin-reader/quoting.t
@@ -54,6 +54,7 @@
       }
     ],
     "stdlib": "lib/ocaml",
+    "unit_name": null,
     "reader": [],
     "protocol": "json",
     "log_file": null,

--- a/tests/test-dirs/config/dot-merlin-reader/quoting.t
+++ b/tests/test-dirs/config/dot-merlin-reader/quoting.t
@@ -55,6 +55,7 @@
     ],
     "stdlib": "lib/ocaml",
     "unit_name": null,
+    "wrapping_prefix": null,
     "reader": [],
     "protocol": "json",
     "log_file": null,


### PR DESCRIPTION
Backport prs [1776](https://github.com/ocaml/merlin/pull/1776) and [1788](https://github.com/ocaml/merlin/pull/1788) from upstream.