### PR TITLE
Backport PR 1753

### DIFF
--- a/src/ocaml/preprocess/lexer_raw.mll
+++ b/src/ocaml/preprocess/lexer_raw.mll
@@ -903,10 +903,8 @@ and comment state = parse
       state.buffer <- buffer;
       Buffer.add_char state.buffer '\"';
       comment state lexbuf }
-  | "{" ('%' '%'? extattrident blank*)? lowercase* "|"
+  | "{" ('%' '%'? extattrident blank*)? (lowercase* as delim) "|"
       {
-        let delim = Lexing.lexeme lexbuf in
-        let delim = String.sub delim ~pos:1 ~len:(String.length delim - 2) in
         state.string_start_loc <- Location.curr lexbuf;
         Buffer.add_string state.buffer (Lexing.lexeme lexbuf);
         (catch (quoted_string delim state lexbuf) (fun e l -> match e with

--- a/tests/test-dirs/errors/issue1753.t
+++ b/tests/test-dirs/errors/issue1753.t
@@ -1,34 +1,9 @@
-FIXME: should be accepted
+should be accepted
   $ $MERLIN single errors -filename main.ml <<'EOF' | \
   > jq '.value[0]'
   > (* {%ext|babar|} *)
   > EOF
-  {
-    "start": {
-      "line": 1,
-      "col": 0
-    },
-    "end": {
-      "line": 1,
-      "col": 2
-    },
-    "type": "typer",
-    "sub": [
-      {
-        "start": {
-          "line": 1,
-          "col": 0
-        },
-        "end": {
-          "line": 1,
-          "col": 2
-        },
-        "message": "String literal begins here"
-      }
-    ],
-    "valid": true,
-    "message": "This comment contains an unterminated string literal"
-  }
+  null
 
 should fail
   $ $MERLIN single errors -filename main.ml <<'EOF' | \
@@ -62,37 +37,12 @@ should fail
     "message": "This comment contains an unterminated string literal"
   }
 
-FIXME: should accept
+should accept
   $ $MERLIN single errors -filename main.ml <<'EOF' | \
   > jq '.value[0]'
   > (* {%ext id|babar|id} *)
   > EOF
-  {
-    "start": {
-      "line": 1,
-      "col": 0
-    },
-    "end": {
-      "line": 1,
-      "col": 2
-    },
-    "type": "typer",
-    "sub": [
-      {
-        "start": {
-          "line": 1,
-          "col": 0
-        },
-        "end": {
-          "line": 1,
-          "col": 2
-        },
-        "message": "String literal begins here"
-      }
-    ],
-    "valid": true,
-    "message": "This comment contains an unterminated string literal"
-  }
+  null
 
 should accept
   $ $MERLIN single errors -filename main.ml <<'EOF' | \

--- a/tests/test-dirs/errors/issue1753.t
+++ b/tests/test-dirs/errors/issue1753.t
@@ -1,0 +1,30 @@
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {%ext|babar|} *)
+  > EOF
+  {
+    "start": {
+      "line": 1,
+      "col": 0
+    },
+    "end": {
+      "line": 1,
+      "col": 2
+    },
+    "type": "typer",
+    "sub": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 2
+        },
+        "message": "String literal begins here"
+      }
+    ],
+    "valid": true,
+    "message": "This comment contains an unterminated string literal"
+  }

--- a/tests/test-dirs/errors/issue1753.t
+++ b/tests/test-dirs/errors/issue1753.t
@@ -1,6 +1,117 @@
+FIXME: should be accepted
   $ $MERLIN single errors -filename main.ml <<'EOF' | \
   > jq '.value[0]'
   > (* {%ext|babar|} *)
+  > EOF
+  {
+    "start": {
+      "line": 1,
+      "col": 0
+    },
+    "end": {
+      "line": 1,
+      "col": 2
+    },
+    "type": "typer",
+    "sub": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 2
+        },
+        "message": "String literal begins here"
+      }
+    ],
+    "valid": true,
+    "message": "This comment contains an unterminated string literal"
+  }
+
+should fail
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {%ext id|babar|} *)
+  > EOF
+  {
+    "start": {
+      "line": 1,
+      "col": 0
+    },
+    "end": {
+      "line": 1,
+      "col": 2
+    },
+    "type": "typer",
+    "sub": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 2
+        },
+        "message": "String literal begins here"
+      }
+    ],
+    "valid": true,
+    "message": "This comment contains an unterminated string literal"
+  }
+
+FIXME: should accept
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {%ext id|babar|id} *)
+  > EOF
+  {
+    "start": {
+      "line": 1,
+      "col": 0
+    },
+    "end": {
+      "line": 1,
+      "col": 2
+    },
+    "type": "typer",
+    "sub": [
+      {
+        "start": {
+          "line": 1,
+          "col": 0
+        },
+        "end": {
+          "line": 1,
+          "col": 2
+        },
+        "message": "String literal begins here"
+      }
+    ],
+    "valid": true,
+    "message": "This comment contains an unterminated string literal"
+  }
+
+should accept
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {id|babar|id} *)
+  > EOF
+  null
+
+should accept
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {|babar|} *)
+  > EOF
+  null
+
+should fail
+  $ $MERLIN single errors -filename main.ml <<'EOF' | \
+  > jq '.value[0]'
+  > (* {id|babar|} *)
   > EOF
   {
     "start": {


### PR DESCRIPTION
Backport [PR 1754](https://github.com/ocaml/merlin/pull/1754), which fixes the incorrect handling of quoted strings in comments.