### PR TITLE
Backport PR #1800

### DIFF
--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -611,16 +611,18 @@ let remove_non_applied_optional_args (Parsetree.{ pexp_desc; _} as base_expr) =
      https://github.com/ocaml/merlin/issues/1770 *)
   match pexp_desc with
   | Parsetree.Pexp_apply (expr, args) ->
-    let args = List.concat_map ~f:(fun (label, expr) ->
-      match label with
-      | Asttypes.Optional str ->
-        (* If an optional parameter is not applied, its location is assumed to
-           be ghost, and the parameter should not be generated. *)
-        let loc = expr.Parsetree.pexp_loc in
-        if loc.loc_ghost
-        then []
-        else begin
-          match need_recover_labeled_args expr.pexp_desc with
+    let args = List.concat_map ~f:(fun (label, (expr : Parsetree.expression)) ->
+      match label, expr.pexp_loc.loc_ghost, expr.pexp_desc with
+      | Asttypes.Optional _, true,
+        Pexp_construct ({loc=_; txt = Longident.Lident "None"}, _) ->
+        (* If the argument to an optional parameter is None and its location is ghost,
+           we choose not to generate the parameter under the assumption that the user
+           did not write it. Note that this could be the incorrect thing to do in the
+           presence of ppxes. But because this we check that the argument is None, this
+           is semantics-preserving if None is not shadowed. *)
+        []
+      | Asttypes.Optional str, false, _ ->
+        begin match need_recover_labeled_args expr.pexp_desc with
           | Some e ->  [(Asttypes.Labelled str, e)]
           | None ->  [(label, expr)]
         end

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -599,9 +599,44 @@ module Conv = struct
     (ps, constrs, labels)
 end
 
+let need_recover_labeled_args = function
+  | Parsetree.Pexp_construct ({loc; txt = Longident.Lident ctor}, Some e) ->
+    (* If the internal construction is ghosted, then the expression must be
+       re-labelled. *)
+    if String.equal "Some" ctor && loc.loc_ghost then Some e else None
+  | _ -> None
+
+let remove_non_applied_optional_args (Parsetree.{ pexp_desc; _} as base_expr) =
+  (* Fix the behaviour described here
+     https://github.com/ocaml/merlin/issues/1770 *)
+  match pexp_desc with
+  | Parsetree.Pexp_apply (expr, args) ->
+    let args = List.concat_map ~f:(fun (label, expr) ->
+      match label with
+      | Asttypes.Optional str ->
+        (* If an optional parameter is not applied, its location is assumed to
+           be ghost, and the parameter should not be generated. *)
+        let loc = expr.Parsetree.pexp_loc in
+        if loc.loc_ghost
+        then []
+        else begin
+          match need_recover_labeled_args expr.pexp_desc with
+          | Some e ->  [(Asttypes.Labelled str, e)]
+          | None ->  [(label, expr)]
+        end
+      | _ -> [(label, expr)]
+    ) args
+    in
+    let pexp_desc = Parsetree.Pexp_apply (expr, args) in
+    { base_expr with pexp_desc }
+  | _ -> base_expr
+
 let destruct_expression loc config source parents expr =
   let ty = expr.Typedtree.exp_type in
-  let pexp = filter_expr_attr (Untypeast.untype_expression expr) in
+  let pexp =
+    filter_expr_attr (Untypeast.untype_expression expr)
+    |> remove_non_applied_optional_args
+  in
   let () =
     log ~title:"node_expression" "%a"
       Logger.fmt (fun fmt -> Printast.expression 0 fmt pexp)

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -611,19 +611,16 @@ let remove_non_applied_optional_args (Parsetree.{ pexp_desc; _} as base_expr) =
      https://github.com/ocaml/merlin/issues/1770 *)
   match pexp_desc with
   | Parsetree.Pexp_apply (expr, args) ->
-    let args = List.concat_map ~f:(fun (label, expr) ->
-      match label with
-      | Asttypes.Optional str ->
-        (* If an optional parameter is not applied, its location is assumed to
-           be ghost, and the parameter should not be generated. *)
-        let loc = expr.Parsetree.pexp_loc in
-        if loc.loc_ghost
-        then []
-        else begin
-          match need_recover_labeled_args expr.pexp_desc with
+    let args = List.concat_map ~f:(fun (label, (expr : Parsetree.expression)) ->
+      match label, expr.pexp_loc.loc_ghost, expr.pexp_desc with
+      | Asttypes.Optional _, true,
+        Pexp_construct ({ txt = Longident.Lident "None"; _ }, _) ->
+        []
+      | Asttypes.Optional str, false, exp_desc ->
+        (match need_recover_labeled_args exp_desc with
           | Some e ->  [(Asttypes.Labelled str, e)]
           | None ->  [(label, expr)]
-        end
+        )
       | _ -> [(label, expr)]
     ) args
     in

--- a/tests/test-dirs/destruct/issue1770.t
+++ b/tests/test-dirs/destruct/issue1770.t
@@ -1,0 +1,162 @@
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?bar x = x
+  > let () = foo ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 15
+        }
+      },
+      "match foo () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+$ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?bar x = x
+  > let () = foo ~bar:10 ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 23
+        }
+      },
+      "match foo ~bar:10 () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?bar x = x
+  > let () = foo ?bar:(Some 10) ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 30
+        }
+      },
+      "match foo ?bar:(Some 10) () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?(bar = 10) x = x
+  > let () = foo ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 15
+        }
+      },
+      "match foo () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?(bar = 10) x = x
+  > let () = foo ~bar:15 ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 23
+        }
+      },
+      "match foo ~bar:15 () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?(bar = 10) x = x
+  > let () = foo ?bar:None ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 25
+        }
+      },
+      "match foo ?bar:None () with | () -> _"
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single case-analysis -start 2:10 -end 2:15 \
+  > -filename main.ml <<EOF
+  > let foo ?(bar = 10) x = x
+  > let () = foo ?bar:(Some 15) ()
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 9
+        },
+        "end": {
+          "line": 2,
+          "col": 30
+        }
+      },
+      "match foo ?bar:(Some 15) () with | () -> _"
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
Backport [PR #1800 from upstream](https://github.com/ocaml/merlin/pull/1800) , which fixes a bug in destructing functions with optional arguments.