### PR TITLE
Backport 1803 - Fix ignorance of STDLIB directive

### DIFF
--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -477,6 +477,7 @@ let postprocess cfg =
         (dirs :> Merlin_dot_protocol.directive list)
       )
     ; (cfg.pass_forward :> Merlin_dot_protocol.directive list)
+    ; cfg.stdlib |> Option.map ~f:(fun stdlib -> `STDLIB stdlib) |> Option.to_list
     ; List.concat_map pkg_paths ~f:(fun p -> [ `B p; `S p ])
     ; ppx
     ; List.map failures ~f:(fun s -> `ERROR_MSG s)

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -11,7 +11,8 @@
   > EOF
   ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir)(?:STDLIB?:/stdlib))
 
-Use ocamlmerlin instead of $MERLIN for this test because $MERLIN configures the stdlib
+Use ocamlmerlin instead of $MERLIN for this test because $MERLIN configures the stdlib,
+but we want to observe the stdlib being configured via the STDLIB directive.
   $ echo | ocamlmerlin single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
   {
     "build_path": [

--- a/tests/test-dirs/config/dot-merlin-reader/load-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/load-config.t
@@ -3,14 +3,16 @@
   > S source/dir
   > BH build-hidden/dir
   > SH source-hidden/dir
+  > STDLIB /stdlib
   > EOF
 
   $ FILE=$(pwd)/test.ml; dot-merlin-reader <<EOF | sed 's#[0-9]*:#?:#g'
   > (4:File${#FILE}:$FILE)
   > EOF
-  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir))
+  ((?:B?:$TESTCASE_ROOT/build/dir)(?:S?:$TESTCASE_ROOT/source/dir)(?:BH?:$TESTCASE_ROOT/build-hidden/dir)(?:SH?:$TESTCASE_ROOT/source-hidden/dir)(?:STDLIB?:/stdlib))
 
-  $ echo | $MERLIN single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
+Use ocamlmerlin instead of $MERLIN for this test because $MERLIN configures the stdlib
+  $ echo | ocamlmerlin single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin'
   {
     "build_path": [
       "$TESTCASE_ROOT/build/dir"
@@ -39,7 +41,7 @@
         "intf": ".rei"
       }
     ],
-    "stdlib": "lib/ocaml",
+    "stdlib": "/stdlib",
     "unit_name": null,
     "wrapping_prefix": null,
     "reader": [],

--- a/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
@@ -1,0 +1,23 @@
+This test uses ocamlmerlin instead of $MERLIN because $MERLIN configures the stdlib
+
+The STDLIB directive in .merlin is respected
+  $ cat > .merlin <<EOF
+  > STDLIB /stdlib1
+  > EOF
+
+  $ echo | ocamlmerlin single dump-configuration -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib1"
+
+  $ rm .merlin
+
+The -ocamlib-path flag is respected
+  $ echo | ocamlmerlin single dump-configuration -ocamllib-path /stdlib2 -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib2"
+
+The STDLIB directive in .merlin takes priority over -ocamllib-path
+  $ cat > .merlin <<EOF
+  > STDLIB /stdlib-from-.merlin
+  > EOF
+
+  $ echo | ocamlmerlin single dump-configuration -ocamllib-path /stdlib-from-flag -filename test.ml 2> /dev/null | jq '.value.merlin.stdlib'
+  "/stdlib-from-.merlin"

--- a/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
+++ b/tests/test-dirs/config/dot-merlin-reader/stdlib-config.t
@@ -1,4 +1,6 @@
-This test uses ocamlmerlin instead of $MERLIN because $MERLIN configures the stdlib
+This test uses ocamlmerlin instead of $MERLIN because $MERLIN configures the stdlib.
+Since this test is testing configuration of the stdlib, we want do not want the
+configuration that $MERLIN gives.
 
 The STDLIB directive in .merlin is respected
   $ cat > .merlin <<EOF


### PR DESCRIPTION
Merlin currently ignores the `STDLIB` directive in `.merlin` files. This PR backports a bugfix to make Merlin use the directive.