### PR TITLE
Backport shape reduce

### DIFF
--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -727,17 +727,22 @@ let find_definition_uid ~config ~env ~(decl : Env_lookup.item) path =
     Logger.fmt (fun fmt -> Shape_reduce.print_result fmt reduced);
   reduced
 
-let rec uid_of_aliases ~traverse_aliases = function
-  | [] -> assert false
-  | [ def ] -> def
-  | (Shape.Uid.Item { comp_unit; _ })
-    :: (((Compilation_unit comp_unit') :: _) as tl)
-    when let by = comp_unit ^ "__" in String.is_prefixed ~by comp_unit' ->
+let rec uid_of_result ~traverse_aliases = function
+  | Shape_reduce.Resolved uid ->
+      Some uid, false
+  | Resolved_alias (Item { comp_unit; _ },
+      (Resolved_alias (Compilation_unit comp_unit', _) as rest))
+      when let by = comp_unit ^ "__" in String.is_prefixed ~by comp_unit' ->
       (* Always traverse dune-wrapper aliases *)
-      uid_of_aliases ~traverse_aliases tl
-  | [ alias; def ] -> if traverse_aliases then def else alias
-  | _alias :: tl when traverse_aliases -> uid_of_aliases ~traverse_aliases tl
-  | alias :: _tl -> alias
+      uid_of_result ~traverse_aliases rest
+  | Resolved_alias (_alias, rest) when traverse_aliases ->
+      uid_of_result ~traverse_aliases rest
+  | Resolved_alias (alias, _rest) ->
+      Some alias, false
+  | Unresolved { uid = Some uid; desc = Comp_unit _; approximated; hash = _ } ->
+      Some uid, approximated
+  | Approximated _ | Unresolved _ | Internal_error_missing_uid ->
+      None, true
 
 (** This is the main function here *)
 let from_path ~config ~env ~local_defs ~decl path =
@@ -758,12 +763,10 @@ let from_path ~config ~env ~local_defs ~decl path =
     | `MLI -> decl.uid, false
     | `ML ->
       let traverse_aliases = config.traverse_aliases in
-      match find_definition_uid ~config ~env ~decl path with
-      | Resolved uid -> uid, false
-      | Resolved_alias aliases -> uid_of_aliases ~traverse_aliases aliases, false
-      | Unresolved { uid = Some uid; desc = Comp_unit _; approximated; hash = _ } ->
-          uid, approximated
-      | Approximated _ | Unresolved _ | Internal_error_missing_uid ->
+      let result = find_definition_uid ~config ~env ~decl path in
+      match uid_of_result ~traverse_aliases result with
+      | Some uid, approx -> uid, approx
+      | None, _approx ->
           log ~title "No definition uid, falling back to the declaration uid: %a"
             Logger.fmt (Fun.flip Shape.Uid.print decl.uid);
           decl.uid, true

--- a/src/analysis/locate.mli
+++ b/src/analysis/locate.mli
@@ -50,7 +50,10 @@ type result = {
   approximated: bool;
 }
 
-val uid_of_aliases : traverse_aliases:bool -> Shape.Uid.t list -> Shape.Uid.t
+val uid_of_result
+  : traverse_aliases:bool
+  -> Shape_reduce.result
+  -> Shape.Uid.t option * bool
 
 val find_source
   : config: Mconfig.t

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -75,27 +75,21 @@ let index_buffer_ ~scope ~current_buffer_path ~local_defs () =
       | path_shape ->
         log ~title:"index_buffer" "Shape of path: %a"
           Logger.fmt (Fun.flip Shape.print path_shape);
-        begin match Shape_reduce.reduce_for_uid env path_shape with
-        | Internal_error_missing_uid ->
-          log ~title:"index_buffer" "Reduction failed: missing uid";
-          index_decl ()
-        | Resolved_alias l ->
-            let uid = Locate.uid_of_aliases ~traverse_aliases:false l in
-            Index_format.(add defs uid (LidSet.singleton lid))
-        | Resolved uid ->
+        let result =  Shape_reduce.reduce_for_uid env path_shape in
+        begin match Locate.uid_of_result ~traverse_aliases:false result with
+        | Some uid, false ->
           log ~title:"index_buffer" "Found %s (%a) wiht uid %a"
             (Longident.head lid.txt)
             Logger.fmt (Fun.flip Location.print_loc lid.loc)
             Logger.fmt (Fun.flip Shape.Uid.print uid);
-          Index_format.(add defs uid (LidSet.singleton lid))
-        | Approximated s  ->
-          log ~title:"index_buffer" "Shape is approximative, found uid: %a"
-            Logger.fmt (Fun.flip (Format.pp_print_option Shape.Uid.print) s);
-          index_decl ()
-        | Unresolved s ->
-          log ~title:"index_buffer" "Shape unresolved, stuck on: %a"
-            Logger.fmt (Fun.flip Shape.print s);
-          index_decl ()
+            Index_format.(add defs uid (LidSet.singleton lid))
+          | Some uid, true ->
+            log ~title:"index_buffer" "Shape is approximative, found uid: %a"
+              Logger.fmt (Fun.flip Shape.Uid.print uid);
+            index_decl ()
+          | None, _ ->
+            log ~title:"index_buffer" "Reduction failed: missing uid";
+            index_decl ()
         end
   in
   let f ~namespace env path (lid : Longident.t Location.loc)  =

--- a/src/ocaml/typing/shape_reduce.ml
+++ b/src/ocaml/typing/shape_reduce.ml
@@ -19,19 +19,18 @@ open Shape
 
 type result =
   | Resolved of Uid.t
-  | Resolved_alias of Uid.t list
+  | Resolved_alias of Uid.t * result
   | Unresolved of t
   | Approximated of Uid.t option
   | Internal_error_missing_uid
 
-let print_result fmt result =
+let rec print_result fmt result =
   match result with
   | Resolved uid ->
       Format.fprintf fmt "@[Resolved: %a@]@;" Uid.print uid
-  | Resolved_alias uids ->
-      Format.fprintf fmt "@[Resolved_alias: %a@]@;"
-        Format.(pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt "@ -> ")
-        Uid.print) uids
+  | Resolved_alias (uid, r) ->
+      Format.fprintf fmt "@[Alias: %a -> %a@]@;"
+        Uid.print uid print_result r
   | Unresolved shape ->
       Format.fprintf fmt "@[Unresolved: %a@]@;" print shape
   | Approximated (Some uid) ->
@@ -222,17 +221,19 @@ end) = struct
      obtained by the same term traversal, adding binders in the same
      order, giving the same balanced trees: the environments have the
      same hash.
-*)
+  *)
+
+  and force env (Thunk (local_env, t)) =
+    reduce_ { env with local_env } t
 
   and reduce__
     ({fuel; global_env; local_env; _} as env) (t : t) =
     let reduce env t = reduce_ env t in
     let delay_reduce env t = Thunk (env.local_env, t) in
-    let force (Thunk (local_env, t)) = reduce { env with local_env } t in
     let return desc = { uid = t.uid; desc; approximated = t.approximated } in
     let rec force_aliases nf = match nf.desc with
       | NAlias delayed_nf ->
-          let nf = force delayed_nf in
+          let nf = force env delayed_nf in
           force_aliases nf
       | _ -> nf
     in
@@ -267,7 +268,7 @@ end) = struct
           | NStruct (items) ->
               begin match Item.Map.find item items with
               | exception Not_found -> nored ()
-              | nf -> force nf |> reset_uid_if_new_binding
+              | nf -> force env nf |> reset_uid_if_new_binding
               end
           | _ ->
               nored ()
@@ -288,7 +289,7 @@ end) = struct
              their binding-time [Uid.t]. *)
           | None -> return (NVar id)
           | Some def ->
-              begin match force def with
+              begin match force env def with
               | { uid = Some _; _  } as nf -> nf
                   (* This var already has a binding uid *)
               | { uid = None; _ } as nf -> { nf with uid = t.uid }
@@ -321,8 +322,7 @@ end) = struct
 
   and read_back_desc ~uid env desc =
     let read_back nf = read_back env nf in
-    let read_back_force (Thunk (local_env, t)) =
-      read_back (reduce_ { env with local_env } t) in
+    let read_back_force dnf = read_back (force env dnf) in
     match desc with
     | NVar v ->
       var (Option.get uid) v
@@ -343,23 +343,6 @@ end) = struct
     | NComp_unit s -> comp_unit ?uid s
     | NAlias nf -> alias ?uid (read_back_force nf)
     | NError t -> error ?uid t
-
-  
-  (* When interested only of in the uid of aliased modules we do not read_back
-    the entire shape of the module, just enough to unroll the chain of aliases.
-  *)
-  let read_back_aliases_uids env (nf : nf) =
-    let force (Thunk (local_env, t)) =
-      reduce_ { env with local_env } t
-    in
-    let rec aux acc (nf : nf) = match nf with
-      | { uid = Some uid; desc = NAlias dnf; _ } ->
-          aux (uid::acc) (force dnf)
-      | { uid = Some uid; _ } ->
-          Resolved_alias (List.rev (uid::acc))
-      | { uid = None; _ } -> Internal_error_missing_uid
-    in
-    aux [] nf
 
   (* Sharing the memo tables is safe at the level of a compilation unit since
     idents should be unique *)
@@ -390,6 +373,21 @@ end) = struct
     | NError _ -> false
     | NLeaf -> false
 
+  let rec reduce_aliases_for_uid env (nf : nf) =
+    match nf with
+    | { uid = Some uid; desc = NAlias dnf; approximated = false; _ } ->
+        let result = reduce_aliases_for_uid env (force env dnf) in
+        Resolved_alias (uid, result)
+    | { uid = Some uid; approximated = false; _ } -> Resolved uid
+    | { uid; approximated = true } -> Approximated uid
+    | { uid = None; approximated = false; _ } ->
+      (* A missing Uid after a complete reduction means the Uid was first
+         missing in the shape which is a code error. Having the
+         [Missing_uid] reported will allow Merlin (or another tool working
+         with the index) to ask users to report the issue if it does happen.
+      *)
+      Internal_error_missing_uid
+
   let reduce_for_uid global_env t =
     let fuel = ref Params.fuel in
     let local_env = Ident.Map.empty in
@@ -403,20 +401,8 @@ end) = struct
     let nf = reduce_ env t in
     if is_stuck_on_comp_unit nf then
       Unresolved (read_back env nf)
-    else match nf with
-      | { desc = NAlias _; approximated = false; _ } ->
-          read_back_aliases_uids env nf
-      | { uid = Some uid; approximated = false; _ } ->
-          Resolved uid
-      | { uid; approximated = true; _ } ->
-          Approximated uid
-      | { uid = None; approximated = false; _ } ->
-          (* A missing Uid after a complete reduction means the Uid was first
-             missing in the shape which is a code error. Having the
-             [Missing_uid] reported will allow Merlin (or another tool working
-             with the index) to ask users to report the issue if it does happen.
-          *)
-          Internal_error_missing_uid
+    else
+      reduce_aliases_for_uid env nf
 end
 
 module Local_reduce =

--- a/src/ocaml/typing/shape_reduce.mli
+++ b/src/ocaml/typing/shape_reduce.mli
@@ -18,10 +18,10 @@
 (** The result of reducing a shape and looking for its uid *)
 type result =
   | Resolved of Shape.Uid.t (** Shape reduction succeeded and a uid was found *)
-  | Resolved_alias of Shape.Uid.t list (** Reduction led to an alias chain *)
+  | Resolved_alias of Shape.Uid.t * result (** Reduction led to an alias *)
   | Unresolved of Shape.t (** Result still contains [Comp_unit] terms *)
   | Approximated of Shape.Uid.t option
-    (** Reduction failed: it can arrive with first-clsss modules for example *)
+    (** Reduction failed: it can arrive with first-class modules for example *)
   | Internal_error_missing_uid
     (** Reduction succeeded but no uid was found, this should never happen *)
 


### PR DESCRIPTION
[PR 2872](https://github.com/ocaml-flambda/flambda-backend/pull/2872) merged some changes to `shape_reduce.ml` into flambda. This PR picks up these changes in Merlin and makes some corresponding changes in `src/analysis`, which are backported from upstream commit [bce24e53e0617579c6a4e2cdc2c35d689ae8da68](https://github.com/ocaml/merlin/commit/bce24e53e0617579c6a4e2cdc2c35d689ae8da68).

Note that `bce24e53e0617579c6a4e2cdc2c35d689ae8da68` also contains some other changes. I believe that these changes are part of a merge from the compiler that are unrelated to the changes to `shape_reduce`.