### PR TITLE
Fix cms magic number issue

### DIFF
--- a/src/index-format/index_format.ml
+++ b/src/index-format/index_format.ml
@@ -91,11 +91,14 @@ let read ~file =
       let file_magic_number = ref (Cmt_format.read_magic_number ic) in
       let cmi_magic_number = Ocaml_utils.Config.cmi_magic_number in
       let cmt_magic_number = Ocaml_utils.Config.cmt_magic_number in
+      let cms_magic_number = Ocaml_utils.Config.cms_magic_number in
       (if String.equal !file_magic_number cmi_magic_number then
          let _ = Cmi_format.input_cmi ic in
-         file_magic_number := Cmt_format.read_magic_number ic);
+         file_magic_number := Cms_format.read_magic_number ic);
       if String.equal !file_magic_number cmt_magic_number then
         Cmt (input_value ic : Cmt_format.cmt_infos)
+      else if String.equal !file_magic_number cms_magic_number then
+        Cms (input_value ic : Cms_format.cms_infos)
       else if String.equal !file_magic_number magic_number then
         Index (input_value ic : index)
       else Unknown)


### PR DESCRIPTION
PR #77 missed this change, which causes Merlin to error when loading a cms file due to not recognizing the magic number.