### PR TITLE
Revert menhir to 20210419

### DIFF
--- a/.github/workflows/flambda-backend.yml
+++ b/.github/workflows/flambda-backend.yml
@@ -89,7 +89,7 @@ jobs:
       working-directory: merlin-jst
       run: |
         opam depext conf-jq --yes # opam depext bug
-        opam pin menhirLib 20231231 --no-action
+        opam pin menhirLib 20210419 --no-action
         opam install --yes ppx_string ppx_compare
         opam install . --deps-only --with-test --yes
 

--- a/merlin-lib.opam
+++ b/merlin-lib.opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "5.1" & < "5.2"}
   "dune" {>= "3.0.0"}
   "csexp" {>= "1.5.1"}
-  "menhir"    {dev & = "20231231"}
-  "menhirLib" {dev & = "20231231"}
-  "menhirSdk" {dev & = "20231231"}
+  "menhir"    {dev & = "20210419"}
+  "menhirLib" {dev & = "20210419"}
+  "menhirSdk" {dev & = "20210419"}
 ]
 synopsis:
   "Merlin's libraries"

--- a/src/ocaml/preprocess/menhirLib.ml
+++ b/src/ocaml/preprocess/menhirLib.ml
@@ -1,11 +1,14 @@
 module General = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -86,11 +89,14 @@ end
 module Convert = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -206,11 +212,14 @@ end
 module IncrementalEngine = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -291,12 +300,12 @@ module type INCREMENTAL_ENGINE = sig
     'a checkpoint
 
   (* [resume] allows the user to resume the parser after it has suspended
-     itself with a checkpoint of the form [Shifting _], [AboutToReduce _], or
-     [HandlingError _]. [resume] expects the old checkpoint and produces a
+     itself with a checkpoint of the form [AboutToReduce (env, prod)] or
+     [HandlingError env]. [resume] expects the old checkpoint and produces a
      new checkpoint. It does not raise any exception. *)
 
   (* The optional argument [strategy] influences the manner in which [resume]
-     deals with checkpoints of the form [HandlingError _]. Its default value
+     deals with checkpoints of the form [ErrorHandling _]. Its default value
      is [`Legacy]. It can be briefly described as follows:
 
      - If the [error] token is used only to report errors (that is, if the
@@ -692,11 +701,14 @@ end
 module EngineTypes = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -774,53 +786,6 @@ type ('state, 'semantic_value, 'token) env = {
   current: 'state;
 
 }
-
-(* --------------------------------------------------------------------------- *)
-
-(* A number of logging hooks are used to (optionally) emit logging messages. *)
-
-(* The comments indicate the conventional messages that correspond
-   to these hooks in the code-based back-end; see [CodeBackend]. *)
-
-module type LOG = sig
-
-  type state
-  type terminal
-  type production
-
-  (* State %d: *)
-
-  val state: state -> unit
-
-  (* Shifting (<terminal>) to state <state> *)
-
-  val shift: terminal -> state -> unit
-
-  (* Reducing a production should be logged either as a reduction
-     event (for regular productions) or as an acceptance event (for
-     start productions). *)
-
-  (* Reducing production <production> / Accepting *)
-
-  val reduce_or_accept: production -> unit
-
-  (* Lookahead token is now <terminal> (<pos>-<pos>) *)
-
-  val lookahead_token: terminal -> Lexing.position -> Lexing.position -> unit
-
-  (* Initiating error handling *)
-
-  val initiating_error_handling: unit -> unit
-
-  (* Resuming error handling *)
-
-  val resuming_error_handling: unit -> unit
-
-  (* Handling error in state <state> *)
-
-  val handling_error: state -> unit
-
-end
 
 (* --------------------------------------------------------------------------- *)
 
@@ -945,16 +910,6 @@ module type TABLE = sig
     ('env -> 'answer) ->
     'env -> 'answer
 
-  (**[maybe_shift_t s t] determines whether there exists a transition out of
-     the state [s], labeled with the terminal symbol [t], to some state
-     [s']. If so, it returns [Some s']. Otherwise, it returns [None]. *)
-  val maybe_shift_t : state -> terminal -> state option
-
-  (**[may_reduce_prod s t prod] determines whether in the state [s], with
-     lookahead symbol [t], the automaton reduces production [prod]. This test
-     accounts for the possible existence of a default reduction. *)
-  val may_reduce_prod : state -> terminal -> production -> bool
-
   (* This is the automaton's goto table. This table maps a pair of a state
      and a nonterminal symbol to a new state. By extension, it also maps a
      pair of a state and a production to a new state. *)
@@ -969,11 +924,6 @@ module type TABLE = sig
   val       goto_nt  : state -> nonterminal -> state
   val       goto_prod: state -> production  -> state
   val maybe_goto_nt:   state -> nonterminal -> state option
-
-  (* [lhs prod] returns the left-hand side of production [prod],
-     a nonterminal symbol. *)
-
-  val lhs: production -> nonterminal
 
   (* [is_start prod] tells whether the production [prod] is a start production. *)
 
@@ -1015,17 +965,51 @@ module type TABLE = sig
 
   val may_reduce: state -> production -> bool
 
+  (* The LR engine requires a number of hooks, which are used for logging. *)
+
+  (* The comments below indicate the conventional messages that correspond
+     to these hooks in the code-based back-end; see [CodeBackend]. *)
+
   (* If the flag [log] is false, then the logging functions are not called.
      If it is [true], then they are called. *)
 
   val log : bool
 
-  (* The logging hooks required by the LR engine. *)
+  module Log : sig
 
-  module Log : LOG
-    with type state := state
-     and type terminal := terminal
-     and type production := production
+    (* State %d: *)
+
+    val state: state -> unit
+
+    (* Shifting (<terminal>) to state <state> *)
+
+    val shift: terminal -> state -> unit
+
+    (* Reducing a production should be logged either as a reduction
+       event (for regular productions) or as an acceptance event (for
+       start productions). *)
+
+    (* Reducing production <production> / Accepting *)
+
+    val reduce_or_accept: production -> unit
+
+    (* Lookahead token is now <terminal> (<pos>-<pos>) *)
+
+    val lookahead_token: terminal -> Lexing.position -> Lexing.position -> unit
+
+    (* Initiating error handling *)
+
+    val initiating_error_handling: unit -> unit
+
+    (* Resuming error handling *)
+
+    val resuming_error_handling: unit -> unit
+
+    (* Handling error in state <state> *)
+
+    val handling_error: state -> unit
+
+  end
 
 end
 
@@ -1118,11 +1102,14 @@ end
 module Engine = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1269,7 +1256,8 @@ module Make (T : TABLE) = struct
 
   (* The following recursive group of functions are tail recursive, produce a
      checkpoint of type [semantic_value checkpoint], and cannot raise an
-     exception. *)
+     exception. A semantic action can raise [Error], but this exception is
+     immediately caught within [reduce]. *)
 
   let rec run env please_discard : semantic_value checkpoint =
 
@@ -1425,22 +1413,33 @@ module Make (T : TABLE) = struct
 
     (* Invoke the semantic action. The semantic action is responsible for
        truncating the stack and pushing a new cell onto the stack, which
-       contains a new semantic value. The semantic action returns a new stack,
+       contains a new semantic value. It can raise [Error]. *)
+
+    (* If the semantic action terminates normally, it returns a new stack,
        which becomes the current stack. *)
 
-    let stack = T.semantic_action prod env in
+    (* If the semantic action raises [Error], we catch it and initiate error
+       handling. *)
 
-    (* By our convention, the semantic action has produced an updated
-       stack. The state now found in the top stack cell is the return
-       state. *)
+    (* This [match/with/exception] construct requires OCaml 4.02. *)
 
-    (* Perform a goto transition. The target state is determined
-       by consulting the goto table at the return state and at
-       production [prod]. *)
+    match T.semantic_action prod env with
+    | stack ->
 
-    let current = T.goto_prod stack.state prod in
-    let env = { env with stack; current } in
-    run env false
+        (* By our convention, the semantic action has produced an updated
+           stack. The state now found in the top stack cell is the return
+           state. *)
+
+        (* Perform a goto transition. The target state is determined
+           by consulting the goto table at the return state and at
+           production [prod]. *)
+
+        let current = T.goto_prod stack.state prod in
+        let env = { env with stack; current } in
+        run env false
+
+    | exception Error ->
+        initiate env
 
   and accept env prod =
     (* Log an accept event. *)
@@ -1619,10 +1618,10 @@ module Make (T : TABLE) = struct
      checkpoint of the form [InputNeeded env]. It checks that [checkpoint] is
      indeed of this form, and invokes [discard]. *)
 
-  (* [resume checkpoint] is invoked by the user in response to a checkpoint
-     of the form [Shifting _], [AboutToReduce _], or [HandlingError env]. It
-     checks that [checkpoint] is indeed of this form, and invokes [reduce]
-     or [error], as appropriate. *)
+  (* [resume checkpoint] is invoked by the user in response to a checkpoint of
+     the form [AboutToReduce (env, prod)] or [HandlingError env]. It checks
+     that [checkpoint] is indeed of this form, and invokes [reduce] or
+     [error], as appropriate. *)
 
   (* In reality, [offer] and [resume] accept an argument of type
      [semantic_value checkpoint] and produce a checkpoint of the same type.
@@ -2064,11 +2063,14 @@ end
 module ErrorReports = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2227,11 +2229,14 @@ end
 module LexerUtil = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2275,40 +2280,18 @@ let range ((pos1, pos2) as range) =
     sprintf "File \"%s\", line %d, characters %d-%d:\n"
       file line char1 char2
       (* use [char1 + 1] and [char2 + 1] if *not* using Caml mode *)
-
-let tabulate (type a) (is_eof : a -> bool) (lexer : unit -> a) : unit -> a =
-  (* Read tokens from the lexer until we hit an EOF token. *)
-  let rec read tokens =
-    let token = lexer() in
-    let tokens = token :: tokens in
-    if is_eof token then
-      (* Once done, reverse the list and convert it to an array. *)
-      tokens |> List.rev |> Array.of_list
-    else
-      read tokens
-  in
-  (* We now have an array of tokens. *)
-  let tokens = read [] in
-  (* Define a pseudo-lexer that reads from this array. *)
-  let i = ref 0 in
-  let lexer () =
-    (* If this assertion is violated, then the parser is trying to read
-       past an EOF token. This should not happen. *)
-    assert (!i < Array.length tokens);
-    let token = Array.unsafe_get tokens !i in
-    i := !i + 1;
-    token
-  in
-  lexer
 end
 module Printers = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2424,11 +2407,14 @@ end
 module InfiniteArray = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2486,11 +2472,14 @@ end
 module PackedIntArray = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2692,11 +2681,14 @@ end
 module RowDisplacement = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -2949,11 +2941,14 @@ end
 module LinearizedArray = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -3028,11 +3023,14 @@ end
 module TableFormat = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -3164,11 +3162,14 @@ end
 module InspectionTableFormat = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -3237,11 +3238,14 @@ end
 module InspectionTableInterpreter = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -3545,11 +3549,14 @@ end
 module TableInterpreter = struct
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -3623,12 +3630,9 @@ module MakeEngineTable (T : TableFormat.TABLES) = struct
   let default_reduction state defred nodefred env =
     let code = PackedIntArray.get T.default_reduction state in
     if code = 0 then
-      (* no default reduction *)
       nodefred env
     else
-      (* default reduction *)
-      let prod = code - 1 in
-      defred env prod
+      defred env (code - 1)
 
   let is_start prod =
     prod < T.start
@@ -3662,59 +3666,13 @@ module MakeEngineTable (T : TableFormat.TABLES) = struct
         assert (c = 0);
         fail env
 
-  let maybe_shift_t state terminal =
-    match PackedIntArray.unflatten1 T.error state terminal with
-    | 1 ->
-        let action = unmarshal2 T.action state terminal in
-        let opcode = action land 0b11 in
-        if opcode >= 0b10 then
-          (* 0b10 : shift/discard *)
-          (* 0b11 : shift/nodiscard *)
-          let state' = action lsr 2 in
-          Some state'
-        else
-          (* 0b01 : reduce *)
-          (* 0b00 : cannot happen *)
-          None
-    | c ->
-        assert (c = 0);
-        None
-
-  let may_reduce_prod state terminal prod =
-    let code = PackedIntArray.get T.default_reduction state in
-    if code = 0 then
-      (* no default reduction *)
-      match PackedIntArray.unflatten1 T.error state terminal with
-      | 1 ->
-          let action = unmarshal2 T.action state terminal in
-          let opcode = action land 0b11 in
-          if opcode >= 0b10 then
-            (* 0b10 : shift/discard *)
-            (* 0b11 : shift/nodiscard *)
-            false
-          else
-            (* 0b01 : reduce *)
-            (* 0b00 : cannot happen *)
-            let prod' = action lsr 2 in
-            prod = prod'
-      | c ->
-          assert (c = 0);
-          false
-    else
-      (* default reduction *)
-      let prod' = code - 1 in
-      prod = prod'
-
   let goto_nt state nt =
     let code = unmarshal2 T.goto state nt in
     (* code = 1 + state *)
     code - 1
 
-  let[@inline] lhs prod =
-    PackedIntArray.get T.lhs prod
-
   let goto_prod state prod =
-    goto_nt state (lhs prod)
+    goto_nt state (PackedIntArray.get T.lhs prod)
 
   let maybe_goto_nt state nt =
     let code = unmarshal2 T.goto state nt in
@@ -3834,5 +3792,5 @@ module MakeEngineTable (T : TableFormat.TABLES) = struct
 end
 end
 module StaticVersion = struct
-let require_20231231 = ()
+let require_20210419 = ()
 end

--- a/src/ocaml/preprocess/menhirLib.mli
+++ b/src/ocaml/preprocess/menhirLib.mli
@@ -1,11 +1,14 @@
 module General : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -62,11 +65,14 @@ end
 module Convert : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -138,11 +144,14 @@ end
 module IncrementalEngine : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -223,12 +232,12 @@ module type INCREMENTAL_ENGINE = sig
     'a checkpoint
 
   (* [resume] allows the user to resume the parser after it has suspended
-     itself with a checkpoint of the form [Shifting _], [AboutToReduce _], or
-     [HandlingError _]. [resume] expects the old checkpoint and produces a
+     itself with a checkpoint of the form [AboutToReduce (env, prod)] or
+     [HandlingError env]. [resume] expects the old checkpoint and produces a
      new checkpoint. It does not raise any exception. *)
 
   (* The optional argument [strategy] influences the manner in which [resume]
-     deals with checkpoints of the form [HandlingError _]. Its default value
+     deals with checkpoints of the form [ErrorHandling _]. Its default value
      is [`Legacy]. It can be briefly described as follows:
 
      - If the [error] token is used only to report errors (that is, if the
@@ -624,11 +633,14 @@ end
 module EngineTypes : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -706,53 +718,6 @@ type ('state, 'semantic_value, 'token) env = {
   current: 'state;
 
 }
-
-(* --------------------------------------------------------------------------- *)
-
-(* A number of logging hooks are used to (optionally) emit logging messages. *)
-
-(* The comments indicate the conventional messages that correspond
-   to these hooks in the code-based back-end; see [CodeBackend]. *)
-
-module type LOG = sig
-
-  type state
-  type terminal
-  type production
-
-  (* State %d: *)
-
-  val state: state -> unit
-
-  (* Shifting (<terminal>) to state <state> *)
-
-  val shift: terminal -> state -> unit
-
-  (* Reducing a production should be logged either as a reduction
-     event (for regular productions) or as an acceptance event (for
-     start productions). *)
-
-  (* Reducing production <production> / Accepting *)
-
-  val reduce_or_accept: production -> unit
-
-  (* Lookahead token is now <terminal> (<pos>-<pos>) *)
-
-  val lookahead_token: terminal -> Lexing.position -> Lexing.position -> unit
-
-  (* Initiating error handling *)
-
-  val initiating_error_handling: unit -> unit
-
-  (* Resuming error handling *)
-
-  val resuming_error_handling: unit -> unit
-
-  (* Handling error in state <state> *)
-
-  val handling_error: state -> unit
-
-end
 
 (* --------------------------------------------------------------------------- *)
 
@@ -877,16 +842,6 @@ module type TABLE = sig
     ('env -> 'answer) ->
     'env -> 'answer
 
-  (**[maybe_shift_t s t] determines whether there exists a transition out of
-     the state [s], labeled with the terminal symbol [t], to some state
-     [s']. If so, it returns [Some s']. Otherwise, it returns [None]. *)
-  val maybe_shift_t : state -> terminal -> state option
-
-  (**[may_reduce_prod s t prod] determines whether in the state [s], with
-     lookahead symbol [t], the automaton reduces production [prod]. This test
-     accounts for the possible existence of a default reduction. *)
-  val may_reduce_prod : state -> terminal -> production -> bool
-
   (* This is the automaton's goto table. This table maps a pair of a state
      and a nonterminal symbol to a new state. By extension, it also maps a
      pair of a state and a production to a new state. *)
@@ -901,11 +856,6 @@ module type TABLE = sig
   val       goto_nt  : state -> nonterminal -> state
   val       goto_prod: state -> production  -> state
   val maybe_goto_nt:   state -> nonterminal -> state option
-
-  (* [lhs prod] returns the left-hand side of production [prod],
-     a nonterminal symbol. *)
-
-  val lhs: production -> nonterminal
 
   (* [is_start prod] tells whether the production [prod] is a start production. *)
 
@@ -947,17 +897,51 @@ module type TABLE = sig
 
   val may_reduce: state -> production -> bool
 
+  (* The LR engine requires a number of hooks, which are used for logging. *)
+
+  (* The comments below indicate the conventional messages that correspond
+     to these hooks in the code-based back-end; see [CodeBackend]. *)
+
   (* If the flag [log] is false, then the logging functions are not called.
      If it is [true], then they are called. *)
 
   val log : bool
 
-  (* The logging hooks required by the LR engine. *)
+  module Log : sig
 
-  module Log : LOG
-    with type state := state
-     and type terminal := terminal
-     and type production := production
+    (* State %d: *)
+
+    val state: state -> unit
+
+    (* Shifting (<terminal>) to state <state> *)
+
+    val shift: terminal -> state -> unit
+
+    (* Reducing a production should be logged either as a reduction
+       event (for regular productions) or as an acceptance event (for
+       start productions). *)
+
+    (* Reducing production <production> / Accepting *)
+
+    val reduce_or_accept: production -> unit
+
+    (* Lookahead token is now <terminal> (<pos>-<pos>) *)
+
+    val lookahead_token: terminal -> Lexing.position -> Lexing.position -> unit
+
+    (* Initiating error handling *)
+
+    val initiating_error_handling: unit -> unit
+
+    (* Resuming error handling *)
+
+    val resuming_error_handling: unit -> unit
+
+    (* Handling error in state <state> *)
+
+    val handling_error: state -> unit
+
+  end
 
 end
 
@@ -1050,11 +1034,14 @@ end
 module Engine : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1080,11 +1067,14 @@ end
 module ErrorReports : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1157,61 +1147,57 @@ end
 module LexerUtil : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
 open Lexing
 
-(**[init filename lexbuf] initializes the lexing buffer [lexbuf] so
+(* [init filename lexbuf] initializes the lexing buffer [lexbuf] so
    that the positions that are subsequently read from it refer to the
    file [filename]. It returns [lexbuf]. *)
+
 val init: string -> lexbuf -> lexbuf
 
-(**[read filename] reads the entire contents of the file [filename] and
+(* [read filename] reads the entire contents of the file [filename] and
    returns a pair of this content (a string) and a lexing buffer that
    has been initialized, based on this string. *)
+
 val read: string -> string * lexbuf
 
-(**[newline lexbuf] increments the line counter stored within [lexbuf]. It
+(* [newline lexbuf] increments the line counter stored within [lexbuf]. It
    should be invoked by the lexer itself every time a newline character is
    consumed. This allows maintaining a current the line number in [lexbuf]. *)
+
 val newline: lexbuf -> unit
 
-(**[range (startpos, endpos)] prints a textual description of the range
+(* [range (startpos, endpos)] prints a textual description of the range
    delimited by the start and end positions [startpos] and [endpos].
    This description is one line long and ends in a newline character.
    This description mentions the file name, the line number, and a range
    of characters on this line. The line number is correct only if [newline]
    has been correctly used, as described dabove. *)
+
 val range: position * position -> string
-
-(**[tabulate is_eof lexer] tabulates the lexer [lexer]: that is, it
-   immediately runs this lexer all the way until an EOF token is found, stores
-   the tokens in an array in memory, and returns a new lexer which (when
-   invoked) reads tokens from this array. The function [lexer] is not allowed
-   to raise an exception, and must produce a finite stream of tokens: that is,
-   after a finite number of invocations, it must return a token that is
-   identified by the function [is_eof] as an EOF token.
-
-   Both the existing lexer [lexer] and the new lexer returned by [tabulate
-   is_eof lexer] are functions of type [unit -> 'a], where the type ['a] is
-   likely to be instantiated with a triple of a token and two positions, as
-   per the revised lexer API described in the module {!Convert}. *)
-val tabulate: ('a -> bool) -> (unit -> 'a) -> (unit -> 'a)
 end
 module Printers : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1282,11 +1268,14 @@ end
 module InfiniteArray : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1317,11 +1306,14 @@ end
 module PackedIntArray : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1373,11 +1365,14 @@ end
 module RowDisplacement : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1434,11 +1429,14 @@ end
 module LinearizedArray : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1505,11 +1503,14 @@ end
 module TableFormat : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1641,11 +1642,14 @@ end
 module InspectionTableFormat : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1714,11 +1718,14 @@ end
 module InspectionTableInterpreter : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1763,11 +1770,14 @@ end
 module TableInterpreter : sig
 (******************************************************************************)
 (*                                                                            *)
-(*                                    Menhir                                  *)
+(*                                   Menhir                                   *)
 (*                                                                            *)
-(*   Copyright Inria. All rights reserved. This file is distributed under     *)
-(*   the terms of the GNU Library General Public License version 2, with a    *)
-(*   special exception on linking, as described in the file LICENSE.          *)
+(*                       François Pottier, Inria Paris                        *)
+(*              Yann Régis-Gianas, PPS, Université Paris Diderot              *)
+(*                                                                            *)
+(*  Copyright Inria. All rights reserved. This file is distributed under the  *)
+(*  terms of the GNU Library General Public License version 2, with a         *)
+(*  special exception on linking, as described in the file LICENSE.           *)
 (*                                                                            *)
 (******************************************************************************)
 
@@ -1793,5 +1803,5 @@ module MakeEngineTable
      and type nonterminal = int
 end
 module StaticVersion : sig
-val require_20231231: unit
+val require_20210419: unit
 end


### PR DESCRIPTION
In Jane Street's interanl codebase, building with 20231231 is currently problematic. For now, we'll keep this on 20210419 and will upgrade the version in the near future.