### PR TITLE
Add ocaml-index tests using cms files and add `-H` flag

### DIFF
--- a/src/ocaml-index/bin/dune
+++ b/src/ocaml-index/bin/dune
@@ -2,8 +2,9 @@
  (name ocaml_index)
  (public_name ocaml-index)
  (package ocaml-index)
- (libraries lib ocaml_typing merlin_index_format)
+ (libraries lib ocaml_typing ocaml_utils merlin_index_format)
  (flags
   :standard
   -open Ocaml_typing
+  -open Ocaml_utils
   -open Merlin_index_format))

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -8,7 +8,7 @@ let usage_msg =
 let verbose = ref false
 let debug = ref false
 let input_files = ref []
-let build_path = ref ({ visible = []; hidden = [] } : Load_path.paths)
+let build_path_rev = ref ({ visible = []; hidden = [] } : Load_path.paths)
 let output_file = ref "project.ocaml-index"
 let root = ref ""
 let rewrite_root = ref false
@@ -52,11 +52,13 @@ let speclist =
       "Aggregate input-indexes shapes and store them in the new index" );
     ( "-I",
       Arg.String (fun arg ->
-        build_path := { !build_path with visible = arg :: !build_path.visible }),
+        build_path_rev := { !build_path_rev with
+                            visible = arg :: !build_path_rev.visible }),
       "An extra directory to add to the load path" );
     ( "-H",
       Arg.String (fun arg ->
-        build_path := { !build_path with hidden = arg :: !build_path.hidden }),
+        build_path_rev := { !build_path_rev with
+                            hidden = arg :: !build_path_rev.hidden }),
       "An extra hidden directory to add to the load path" );
     ( "--no-cmt-load-path",
       Arg.Set do_not_use_cmt_loadpath,
@@ -77,7 +79,8 @@ let () =
       let root = if String.equal "" !root then None else Some !root in
       Index.from_files ~store_shapes:!store_shapes ~root
         ~rewrite_root:!rewrite_root ~output_file:!output_file
-        ~build_path:!build_path
+        ~build_path:{ visible = List.rev !build_path_rev.visible;
+                      hidden = List.rev !build_path_rev.hidden }
         ~do_not_use_cmt_loadpath:!do_not_use_cmt_loadpath !input_files
   | Some Dump ->
       List.iter

--- a/src/ocaml-index/bin/ocaml_index.ml
+++ b/src/ocaml-index/bin/ocaml_index.ml
@@ -8,7 +8,7 @@ let usage_msg =
 let verbose = ref false
 let debug = ref false
 let input_files = ref []
-let build_path = ref []
+let build_path = ref ({ visible = []; hidden = [] } : Load_path.paths)
 let output_file = ref "project.ocaml-index"
 let root = ref ""
 let rewrite_root = ref false
@@ -51,8 +51,13 @@ let speclist =
       Arg.Set store_shapes,
       "Aggregate input-indexes shapes and store them in the new index" );
     ( "-I",
-      Arg.String (fun arg -> build_path := arg :: !build_path),
+      Arg.String (fun arg ->
+        build_path := { !build_path with visible = arg :: !build_path.visible }),
       "An extra directory to add to the load path" );
+    ( "-H",
+      Arg.String (fun arg ->
+        build_path := { !build_path with hidden = arg :: !build_path.hidden }),
+      "An extra hidden directory to add to the load path" );
     ( "--no-cmt-load-path",
       Arg.Set do_not_use_cmt_loadpath,
       "Do not initialize the load path with the paths found in the first input \

--- a/src/ocaml-index/lib/index.ml
+++ b/src/ocaml-index/lib/index.ml
@@ -73,14 +73,15 @@ end
 
 let init_load_path_once ~do_not_use_cmt_loadpath =
   let loaded = ref false in
-  fun ~dirs cmt_loadpath ->
+  fun ~(dirs : Load_path.paths) cmt_loadpath ->
     if not !loaded then (
       let cmt_visible, cmt_hidden =
         if do_not_use_cmt_loadpath then ([], [])
         else (cmt_loadpath.Load_path.visible, cmt_loadpath.Load_path.hidden)
       in
-      let visible = List.concat [ cmt_visible; dirs ] in
-      Load_path.(init ~auto_include:no_auto_include ~visible ~hidden:cmt_hidden);
+      let visible = List.concat [ cmt_visible; dirs.visible ] in
+      let hidden = List.concat [ cmt_hidden; dirs.hidden ] in
+      Load_path.(init ~auto_include:no_auto_include ~visible ~hidden);
       loaded := true)
 
 let index_of_artifact

--- a/src/ocaml-index/tests/tests-dirs/cmd.t
+++ b/src/ocaml-index/tests/tests-dirs/cmd.t
@@ -11,6 +11,7 @@
     --rewrite-root Rewrite locations paths using the provided root
     --store-shapes Aggregate input-indexes shapes and store them in the new index
     -I An extra directory to add to the load path
+    -H An extra hidden directory to add to the load path
     --no-cmt-load-path Do not initialize the load path with the paths found in the first input cmt file
     -help  Display this list of options
     --help  Display this list of options

--- a/src/ocaml-index/tests/tests-dirs/demonstate-cms-deps.t
+++ b/src/ocaml-index/tests/tests-dirs/demonstate-cms-deps.t
@@ -1,0 +1,73 @@
+This file demonstrates that when using cms files, we must pass dependencies to ocaml-index
+for it to be able to properly index a file. Additionally, we must distinguish between
+-I and -H dependencies to match the compiler's behavior.
+
+  $ cat >main.ml <<EOF
+  > let x : int = Foo.Bar.x
+  > (* The : int demonstrates that Foo.x is from the visible lib, since Foo.x is a string
+  >    in the hidden lib *)
+  > EOF
+
+  $ mkdir visible_lib
+  $ cat >visible_lib/foo.ml <<EOF
+  > module Bar = Bar
+  > EOF
+
+  $ cat >visible_lib/bar.ml <<EOF
+  > let x = 0
+  > EOF
+
+  $ mkdir hidden_lib
+  $ cat >hidden_lib/foo.ml <<EOF
+  > module Bar = struct
+  >   let x = "hello"
+  > end
+  > EOF
+
+  $ $OCAMLC -bin-annot -bin-annot-cms -bin-annot-occurrences -c visible_lib/bar.ml
+  $ $OCAMLC -bin-annot -bin-annot-cms -bin-annot-occurrences -c visible_lib/foo.ml -I visible_lib
+  $ $OCAMLC -bin-annot -bin-annot-cms -bin-annot-occurrences -c hidden_lib/foo.ml
+  $ $OCAMLC -bin-annot -bin-annot-cms -bin-annot-occurrences -c main.ml -H hidden_lib -I visible_lib
+
+If we use cmt files and don't include dependencies, ocaml-index will succeed because cmt
+files include the load-path in them:
+  $ ocaml-index aggregate -o main.uideps main.cmt
+  $ ocaml-index dump main.uideps
+  2 uids:
+  {uid: Bar.0; locs: "Foo.Bar.x": File "main.ml", line 1, characters 14-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5 },
+  0 approx shapes: {}, and shapes for CUS .
+
+If we use cms files and don't include dependencies, ocaml-index will fail to index
+identifiers from dependencies:
+  $ ocaml-index aggregate -o main.uideps main.cms
+  $ ocaml-index dump main.uideps
+  1 uids: {uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5 },
+  0 approx shapes: {}, and shapes for CUS .
+
+If we pass a hidden dependency as a visible one, we can run into trouble. Note that
+ocaml-index believes that "Foo.Bar.x" comes from Foo rather than Bar:
+  $ ocaml-index aggregate -o main.uideps main.cms -I hidden_lib -I visible_lib
+  $ ocaml-index dump main.uideps
+  2 uids:
+  {uid: Foo.0; locs: "Foo.Bar.x": File "main.ml", line 1, characters 14-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5 },
+  0 approx shapes: {}, and shapes for CUS .
+
+If we pass dependencies, we get the correct results:
+  $ ocaml-index aggregate -o main.uideps main.cms -H hidden_lib -I visible_lib
+  $ ocaml-index dump main.uideps
+  2 uids:
+  {uid: Bar.0; locs: "Foo.Bar.x": File "main.ml", line 1, characters 14-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5 },
+  0 approx shapes: {}, and shapes for CUS .
+
+Lastly, check that ocaml-index disambiguates based on order the same as the compiler.
+Since visible_lib comes first, "Foo" in main.ml corresponds to visible_lib/foo.ml:
+  $ $OCAMLC -bin-annot-cms -bin-annot-occurrences -c main.ml -I visible_lib -I hidden_lib
+  $ ocaml-index aggregate -o main.uideps main.cms -I visible_lib -I hidden_lib
+  $ ocaml-index dump main.uideps
+  2 uids:
+  {uid: Bar.0; locs: "Foo.Bar.x": File "main.ml", line 1, characters 14-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5 },
+  0 approx shapes: {}, and shapes for CUS .

--- a/src/ocaml-index/tests/tests-dirs/demonstate-cms-deps.t
+++ b/src/ocaml-index/tests/tests-dirs/demonstate-cms-deps.t
@@ -4,8 +4,8 @@ for it to be able to properly index a file. Additionally, we must distinguish be
 
   $ cat >main.ml <<EOF
   > let x : int = Foo.Bar.x
-  > (* The : int demonstrates that Foo.x is from the visible lib, since Foo.x is a string
-  >    in the hidden lib *)
+  > (* The : int demonstrates that Foo.Bar.x is from the visible lib, since Foo.x is a
+  >    string in the hidden lib *)
   > EOF
 
   $ mkdir visible_lib

--- a/src/ocaml-index/tests/tests-dirs/index-project.t
+++ b/src/ocaml-index/tests/tests-dirs/index-project.t
@@ -132,3 +132,39 @@
   - 0 compilation units shapes
   - root dir: none
   
+
+Jane Street Merlin uses cms files instead of cmt files. Verify that the results using
+cms files are consistent with using cmt files:
+
+  $ $OCAMLC -bin-annot-cms -bin-annot-occurrences -c bar.ml foo.ml main.ml
+
+  $ ocaml-index aggregate -o main.uideps-cms main.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index aggregate -o foo.uideps-cms foo.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index aggregate -o bar.uideps-cms bar.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index -o test.uideps-cms main.cms foo.cms bar.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+
+  $ ocaml-index dump main.uideps > from-cmt.out
+  $ ocaml-index dump main.uideps-cms > from-cms.out
+  $ diff from-cmt.out from-cms.out
+  1c1
+  < 13 uids:
+  ---
+  > 14 uids:
+  24a25
+  >  uid: Main.7; locs: "": File "main.ml", line 10, characters 7-8
+  [1]
+
+  $ ocaml-index dump foo.uideps > from-cmt.out
+  $ ocaml-index dump foo.uideps-cms > from-cms.out
+  $ diff from-cmt.out from-cms.out
+
+  $ ocaml-index dump test.uideps > from-cmt.out
+  $ ocaml-index dump test.uideps-cms > from-cms.out
+  $ diff from-cmt.out from-cms.out
+  1c1
+  < 13 uids:
+  ---
+  > 14 uids:
+  33a34
+  >  uid: Main.7; locs: "": File "main.ml", line 10, characters 7-8
+  [1]

--- a/src/ocaml-index/tests/tests-dirs/index-project.t
+++ b/src/ocaml-index/tests/tests-dirs/index-project.t
@@ -143,6 +143,9 @@ cms files are consistent with using cmt files:
   $ ocaml-index aggregate -o bar.uideps-cms bar.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
   $ ocaml-index -o test.uideps-cms main.cms foo.cms bar.cms -I . -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
 
+The diff here is different. It seems this is because the cms file includes the shape for
+module _ = ..., while the cmt does not. This seems to be an insignificant difference for
+the sake of occurrences, and if anything, the cms behavior seems preferrable.
   $ ocaml-index dump main.uideps > from-cmt.out
   $ ocaml-index dump main.uideps-cms > from-cms.out
   $ diff from-cmt.out from-cms.out

--- a/src/ocaml-index/tests/tests-dirs/transitive-deps-cms.t
+++ b/src/ocaml-index/tests/tests-dirs/transitive-deps-cms.t
@@ -1,0 +1,58 @@
+Jane Street only: This test is similar to transitive-deps.t, except it uses cms files
+instead of cmt files.
+
+  $ cat >main.ml <<EOF
+  > let x = List.init Foo.x (fun n -> n)
+  > EOF
+
+  $ mkdir lib1
+  $ cat >lib1/foo.ml <<EOF
+  > include Bar
+  > EOF
+
+  $ mkdir lib2
+  $ cat >lib2/bar.ml <<EOF
+  > let x = 21
+  > EOF
+
+  $ $OCAMLC -bin-annot-cms -bin-annot-occurrences -c lib2/bar.ml
+  $ $OCAMLC -bin-annot-cms -bin-annot-occurrences -c lib1/foo.ml -I lib2
+
+Here we have an implicit transitive dependency on lib2:
+  $ $OCAMLC -bin-annot-cms -bin-annot-occurrences -c main.ml -I lib1
+
+Here we differ from the cmt version of this test. Since cms files do not include the
+loadpath, we must explicitly pass all dependencies. Additionally, we make a distinction
+between visible and hidden dependencies:
+  $ ocaml-index aggregate -o main.uideps main.cms -I lib1 -I lib2 -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index aggregate -o lib1/foo.uideps lib1/foo.cms -I lib2 -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index aggregate -o lib2/bar.uideps lib2/bar.cms -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+
+  $ ocaml-index aggregate -o test.uideps main.uideps lib1/foo.uideps lib2/bar.uideps
+
+  $ ocaml-index dump main.uideps
+  4 uids:
+  {uid: Bar.0; locs: "Foo.x": File "main.ml", line 1, characters 18-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
+   uid: Main.1; locs: "n": File "main.ml", line 1, characters 34-35
+   uid: Stdlib__List.45; locs:
+     "List.init": File "main.ml", line 1, characters 8-17
+   }, 0 approx shapes: {}, and shapes for CUS .
+
+  $ ocaml-index dump lib1/foo.uideps
+  1 uids:
+  {uid: Bar; locs: "Bar": File "lib1/foo.ml", line 1, characters 8-11 },
+  0 approx shapes: {}, and shapes for CUS .
+
+  $ ocaml-index dump test.uideps
+  5 uids:
+  {uid: Bar; locs: "Bar": File "lib1/foo.ml", line 1, characters 8-11
+   uid: Bar.0; locs:
+     "x": File "lib2/bar.ml", line 1, characters 4-5;
+     "Foo.x": File "main.ml", line 1, characters 18-23
+   uid: Main.0; locs: "x": File "main.ml", line 1, characters 4-5
+   uid: Main.1; locs: "n": File "main.ml", line 1, characters 34-35
+   uid: Stdlib__List.45; locs:
+     "List.init": File "main.ml", line 1, characters 8-17
+   }, 0 approx shapes: {}, and shapes for CUS .
+

--- a/src/ocaml-index/tests/tests-dirs/transitive-deps-cms.t
+++ b/src/ocaml-index/tests/tests-dirs/transitive-deps-cms.t
@@ -24,7 +24,7 @@ Here we have an implicit transitive dependency on lib2:
 Here we differ from the cmt version of this test. Since cms files do not include the
 loadpath, we must explicitly pass all dependencies. Additionally, we make a distinction
 between visible and hidden dependencies:
-  $ ocaml-index aggregate -o main.uideps main.cms -I lib1 -I lib2 -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
+  $ ocaml-index aggregate -o main.uideps main.cms -I lib1 -H lib2 -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
   $ ocaml-index aggregate -o lib1/foo.uideps lib1/foo.cms -I lib2 -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
   $ ocaml-index aggregate -o lib2/bar.uideps lib2/bar.cms -I "$MERLIN_TEST_OCAML_PATH/lib/ocaml"
 


### PR DESCRIPTION
As the title suggests, this PR does two things:
- Add tests that demonstrate ocaml-index working with cms files
- Add a `-H` flag to ocaml-index, which allows passing hidden dependency paths

This is done as 1 PR instead of 2 because the tests rely on the `-H` flag to work properly.