### PR TITLE
Incomplete curried application recovery bugfix

### DIFF
--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -8086,7 +8086,7 @@ and type_application env app_loc expected_mode position_and_mode
             type_omitted_parameters expected_mode env ty_ret mode_ret args
           in
           (try check_curried_application_complete ~env ~app_loc untyped_args
-          with Error _ as exn -> raise_error exn);
+          with exn -> raise_error exn);
           ty_ret, mode_ret, args, position_and_mode
         end ~post:(fun (ty_ret, _, _, _) -> generalize_structure ty_ret)
       in

--- a/src/ocaml/typing/typecore.ml
+++ b/src/ocaml/typing/typecore.ml
@@ -8085,7 +8085,8 @@ and type_application env app_loc expected_mode position_and_mode
           let ty_ret, mode_ret, args =
             type_omitted_parameters expected_mode env ty_ret mode_ret args
           in
-          check_curried_application_complete ~env ~app_loc untyped_args;
+          (try check_curried_application_complete ~env ~app_loc untyped_args
+          with Error _ as exn -> raise_error exn);
           ty_ret, mode_ret, args, position_and_mode
         end ~post:(fun (ty_ret, _, _, _) -> generalize_structure ty_ret)
       in

--- a/tests/test-dirs/locate/ill-typed/curried-local.t
+++ b/tests/test-dirs/locate/ill-typed/curried-local.t
@@ -1,7 +1,7 @@
 Test that Merlin can recover from a function taking local arguments being under-applied
 when performing a locate query.
 
-  $ ocamlmerlin single locate -position 4:15 -filename test.ml << EOF | jq .value
+  $ $MERLIN single locate -position 4:15 -filename test.ml << EOF | jq .value
   > module List = struct
   >   let map : f:('a -> 'b) -> 'a list -> 'b list = failwith ""
   > end
@@ -15,7 +15,7 @@ when performing a locate query.
     }
   }
 
-  $ ocamlmerlin single locate -position 4:15 -filename test.ml << EOF | jq .value
+  $ $MERLIN single locate -position 4:15 -filename test.ml << EOF | jq .value
   > module List = struct
   >   let map : f:local_ ('a -> 'b) -> 'a list -> 'b list = failwith ""
   > end

--- a/tests/test-dirs/locate/ill-typed/curried-local.t
+++ b/tests/test-dirs/locate/ill-typed/curried-local.t
@@ -1,0 +1,24 @@
+Test that Merlin can recover from a function taking local arguments being under-applied
+when performing a locate query.
+
+  $ ocamlmerlin single locate -position 4:15 -filename test.ml << EOF | jq .value
+  > module List = struct
+  >   let map : f:('a -> 'b) -> 'a list -> 'b list = failwith ""
+  > end
+  > let () = List.map ~invalid_arg:2
+  > EOF
+  {
+    "file": "test.ml",
+    "pos": {
+      "line": 2,
+      "col": 6
+    }
+  }
+
+  $ ocamlmerlin single locate -position 4:15 -filename test.ml << EOF | jq .value
+  > module List = struct
+  >   let map : f:local_ ('a -> 'b) -> 'a list -> 'b list = failwith ""
+  > end
+  > let () = List.map ~invalid_arg:2
+  > EOF
+  "Not in environment 'List.map'"

--- a/tests/test-dirs/locate/ill-typed/curried-local.t
+++ b/tests/test-dirs/locate/ill-typed/curried-local.t
@@ -21,4 +21,10 @@ when performing a locate query.
   > end
   > let () = List.map ~invalid_arg:2
   > EOF
-  "Not in environment 'List.map'"
+  {
+    "file": "test.ml",
+    "pos": {
+      "line": 2,
+      "col": 6
+    }
+  }


### PR DESCRIPTION
Fixes error recovery bug for a program like:
```
module List = struct
  let map : f:local_ ('a -> 'b) -> 'a list -> 'b list = failwith ""
end
let () = List.map ~invalid_arg:2
```
This bug would prevent users from being able to jump to the definition of List.map in such cases.