### PR TITLE
Add test for old gadt destruct bug

### DIFF
--- a/tests/test-dirs/destruct/gadt-cross-module.t
+++ b/tests/test-dirs/destruct/gadt-cross-module.t
@@ -1,0 +1,41 @@
+  $ mkdir lib
+  $ cat >lib/gadt.ml <<EOF
+  > type _ u =
+  >   | A : A.t u
+  >   | B : B.t u
+  > type packed = Packed : _ u -> packed
+  > type 'a t = 'a u
+  > EOF
+
+  $ cat >lib/a.ml <<EOF
+  > type t = int
+  > EOF
+
+  $ cat >lib/b.ml <<EOF
+  > type t = string
+  > EOF
+
+  $ $OCAMLC -I lib lib/a.ml lib/b.ml lib/gadt.ml
+
+  $ $MERLIN single case-analysis -I lib -start 3:5 -end 3:5 -filename client.ml <<EOF
+  > let f (Packed t : Gadt.packed) =
+  >   match (t : _ Gadt.t) with
+  >   | _ -> assert false
+  > EOF
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 4
+        },
+        "end": {
+          "line": 3,
+          "col": 5
+        }
+      },
+      "Gadt.A | Gadt.B"
+    ],
+    "notifications": []
+  }


### PR DESCRIPTION
PR #38 is an old PR that introduces a hacky workaround to a case that caused Merlin to crash. That bug has since been resolved (presumably due to changes merged from flambda). This PR adds a regression test for the old bug.