### PR TITLE
Fix EXCLUDE_QUERY_DIR for cms/cmt files

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -1021,7 +1021,9 @@ let cmt_path config =
   let stdlib = stdlib config in
   let exp_dirs = List.map ~f:(Misc.expand_directory stdlib) dirs in
   let stdlib = if config.ocaml.no_std_include then [] else [ stdlib ] in
-  config.query.directory :: List.rev_append exp_dirs stdlib
+  let result' = List.rev_append exp_dirs stdlib in
+  if config.merlin.exclude_query_dir then result'
+  else config.query.directory :: result'
 
 let global_modules ?(include_current = false) config =
   let modules = Misc.modules_in_path ~ext:".cmi" (build_path config) in

--- a/tests/test-dirs/config/exclude-query-dir.t
+++ b/tests/test-dirs/config/exclude-query-dir.t
@@ -1,0 +1,40 @@
+Test the EXCLUDE_QUERY_DIR directive, which tells Merlin not to look for build artifacts
+in the directory of the file being queried on. To test, we create a/test.ml, which depends
+on b/foo.ml. The folder b contains a .cms for the Foo module, and Merlin is configured to
+look there. We also include a malformatted foo.cms in the query directory.
+  $ mkdir a
+  $ mkdir b
+
+  $ cat > a/test.ml << EOF
+  > let x = Foo.bar
+  > EOF
+
+  $ cat > b/foo.ml << EOF
+  > let bar = 10
+  > EOF
+
+Create the proper and malformatted .cms files
+  $ $OCAMLC -c -bin-annot-cms b/foo.ml
+  $ touch a/foo.cms
+
+Configure Merlin
+  $ cat > a/.merlin << EOF
+  > S .
+  > B ../b
+  > S ../b
+  > EXCLUDE_QUERY_DIR
+  > EOF
+
+Perform the query
+  $ $MERLIN single locate -position 1:13 -filename a/test.ml < a/test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/b/foo.ml",
+      "pos": {
+        "line": 1,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/config/exclude-query-dir.t
+++ b/tests/test-dirs/config/exclude-query-dir.t
@@ -1,7 +1,7 @@
 Test the EXCLUDE_QUERY_DIR directive, which tells Merlin not to look for build artifacts
 in the directory of the file being queried on. To test, we create a/test.ml, which depends
-on b/foo.ml. The folder b contains a .cms for the Foo module, and Merlin is configured to
-look there. We also include a malformatted foo.cms in the query directory.
+on b/foo.ml. The folder b contains a .cmt for the Foo module, and Merlin is configured to
+look there. We also include a malformatted foo.cmt in the query directory.
   $ mkdir a
   $ mkdir b
 
@@ -13,9 +13,9 @@ look there. We also include a malformatted foo.cms in the query directory.
   > let bar = 10
   > EOF
 
-Create the proper and malformatted .cms files
-  $ $OCAMLC -c -bin-annot-cms b/foo.ml
-  $ touch a/foo.cms
+Create the proper and malformatted .cmt files
+  $ $OCAMLC -c -bin-annot b/foo.ml
+  $ touch a/foo.cmt
 
 Configure Merlin
   $ cat > a/.merlin << EOF
@@ -26,6 +26,29 @@ Configure Merlin
   > EOF
 
 Perform the query
+  $ $MERLIN single locate -position 1:13 -filename a/test.ml < a/test.ml
+  {
+    "class": "return",
+    "value": {
+      "file": "$TESTCASE_ROOT/b/foo.ml",
+      "pos": {
+        "line": 1,
+        "col": 4
+      }
+    },
+    "notifications": []
+  }
+
+Jane Street Only: run the same test as above, but with .cms files instead of .cmt
+
+Remove the old .cmt files
+  $ rm **/*.cmt
+
+Create the .cms files
+  $ $OCAMLC -c -bin-annot b/foo.ml
+  $ touch a/foo.cmt
+
+Perform the query again
   $ $MERLIN single locate -position 1:13 -filename a/test.ml < a/test.ml
   {
     "class": "return",


### PR DESCRIPTION
Resolve a bug where Merlin does not respect the `EXCLUDE_QUERY_DIR` directive for cmt/cms files. I believe this bug is present upstream, so I intend to upstream this PR.