### PR TITLE
Add script to update magic numbers

### DIFF
--- a/src/ocaml/typing/magic_numbers.ml
+++ b/src/ocaml/typing/magic_numbers.ml
@@ -35,6 +35,8 @@ module Cmi = struct
     | "Caml1999I512" -> Some "4.14.1-19"
     | "Caml1999I513" -> Some "4.14.1-22"
     | "Caml1999I514" -> Some "4.14.1-24"
+    | "Caml1999I032" -> Some "5.0"
+    | "Caml1999I033" -> Some "5.1"
     | "Caml1999I520" -> Some "5.1.1minus"
     | "Caml1999I521" -> Some "5.1.1minus-4"
     | "Caml1999I522" -> Some "5.1.1minus-8"
@@ -52,11 +54,9 @@ module Cmi = struct
     | "Caml1999I535" -> Some "5.1.1minus-21"
     | "Caml1999I536" -> Some "5.1.1minus-23"
     | "Caml1999I537" -> Some "5.1.1minus-24"
+    | "Caml1999I034" -> Some "5.2"
     | "Caml1999I550" -> Some "5.2.0minus-0"
     | "Caml1999I551" -> Some "5.2.0minus-1"
-    | "Caml1999I032" -> Some "5.0"
-    | "Caml1999I033" -> Some "5.1"
-    | "Caml1999I034" -> Some "5.2"
     | _ -> None
 
   let () = assert (to_version_opt Config.cmi_magic_number <> None)

--- a/src/ocaml/utils/config.ml
+++ b/src/ocaml/utils/config.ml
@@ -22,24 +22,22 @@
 (**                                                                   **)
 (***********************************************************************)
 
-(* merlin-jst: All magic numbers ending in "500" (or higher) should not change when we
+(* merlin-jst: All magic numbers ending in `500` (or higher) should not change when we
    upgrade the upstream Merlin version.  Otherwise, this should track
-   "utils/config.mlp" from the compiler.  Also, the above warning comment about
-   "config.mlbuild" is outdated and can be ignored. *)
+   `utils/config.mlp` from the compiler.  Also, the above warning comment about
+   `config.mlbuild` is outdated and can be ignored. *)
 
 (* The main OCaml version string has moved to ../VERSION *)
 let version = Sys.ocaml_version
 
-let ext_obj = ".o_The boot compiler cannot process C objects"
+(* When bumping this number, be sure to also update ../typing/magic_numbers.ml *)
+let cmi_magic_number = "Caml1999I551"
 
-let cmi_magic_number =
-  (* When bumping this number, be sure to also update ../typing/magic_numbers.ml *)
-  "Caml1999I551"
-and ast_impl_magic_number = "Caml1999M551"
-and ast_intf_magic_number = "Caml1999N551"
-and cmt_magic_number = "Caml1999T551"
-and cms_magic_number = "Caml1999S551"
-and index_magic_number = "Merl2023I501"
+let ast_impl_magic_number = "Caml1999M551"
+let ast_intf_magic_number = "Caml1999N551"
+let cmt_magic_number = "Caml1999T551"
+let cms_magic_number = "Caml1999S551"
+let index_magic_number = "Merl2023I501"
 
 let interface_suffix = ref ".mli"
 

--- a/src/ocaml/utils/config.mli
+++ b/src/ocaml/utils/config.mli
@@ -18,8 +18,6 @@
 val version: string
         (* The current version number of the system *)
 
-val ext_obj : string
-
 val interface_suffix: string ref
         (* Suffix for interface file names *)
 

--- a/update-magic-numbers.sh
+++ b/update-magic-numbers.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# This script updates the magic numbers in src/ocaml/utils/config.ml and
+# src/ocaml/typing/magic_numbers.ml based on the magic numbers in
+# upstream/ocaml_flambda/configure
+
+source_file=upstream/ocaml_flambda/configure
+target_magic_file=src/ocaml/typing/magic_numbers.ml
+target_config_file=src/ocaml/utils/config.ml
+
+function usage () {
+  cat <<USAGE
+Usage: $0 VERSION
+
+Update the magic numbers in $target_config_file and $target_magic_file
+based on the magic numbers in $source_file.
+
+VERSION is the OCaml version that this version of Merlin corresponds to.
+USAGE
+}
+
+if [[ $# = 1 ]]; then
+  case "$1" in
+  -h|-help|--help|-\?)
+    usage
+    exit 0
+    ;;
+  *)
+    version="$1"
+    ;;
+  esac
+else
+  usage >&2
+  exit 1
+fi
+
+# Check that git repo is clean
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Git workspace is unclean.\nCommit changes before continuing to ensure changes don't get overwritten" >&2
+  exit 1
+fi
+
+# Collect magic numbers by greping for them in upstream/ocaml_flambda/configure
+cmi_magic_number=$(grep -oP 'CMI_MAGIC_NUMBER=\K[a-zA-Z0-9]*' "$source_file")
+ast_impl_magic_number=$(grep -oP 'AST_IMPL_MAGIC_NUMBER=\K[a-zA-Z0-9]*' "$source_file")
+ast_intf_magic_number=$(grep -oP 'AST_INTF_MAGIC_NUMBER=\K[a-zA-Z0-9]*' "$source_file")
+cmt_magic_number=$(grep -oP 'CMT_MAGIC_NUMBER=\K[a-zA-Z0-9]*' "$source_file")
+cms_magic_number=$(grep -oP 'CMS_MAGIC_NUMBER=\K[a-zA-Z0-9]*' "$source_file")
+
+# Create an index magic number based on the cmi magic number.
+# The cmi magic number is expected to be start with Caml1999I and end in some number.
+# The index magic number is made to be Merl2023I, suffixed with that number.
+# ex: Caml1999I551 -> Merl2023I551
+index_magic_number=$(echo "$cmi_magic_number" | sed -E 's/Caml1999I([0-9]+)/Merl2023I\1/')
+
+# Update src/ocaml/typing/magic_numbers.ml
+if grep -q "$version" "$target_magic_file"; then
+  echo "$target_magic_file already contains magic number for $version; skipping"
+else
+  echo "Updating magic numbers in $target_magic_file"
+  line_to_insert="| \"$cmi_magic_number\" -> Some \"$version\""
+  # The below sed looks for a line like:
+  #    | "Caml1999I551" -> Some "5.2.0minus-1"
+  # followed by a line like:
+  #    | _ -> None
+  # and inserts $line_to_insert between them.
+  # The :a;N;$!ba; is some sed magic that makes it read in the entire file before
+  # substituting, which is necessary to match mutli-line patterns.
+  sed -i -E ':a;N;$!ba;s/(\| "[a-zA-Z0-9]+" -> Some "\S*")\n(\s*)(\| _ -> None)/\1\n\2'"$line_to_insert"'\n\2\3/' "$target_magic_file"
+fi
+
+# Update the magic numbers in src/ocaml/utils/config.ml
+echo "Updating magic numbers in $target_config_file"
+function replace_magic_number () {
+  name="$1"
+  value="$2"
+  sed -i 's/let '"$name"' = "[^"]*"/let '"$name"' = "'"$value"'"/' "$target_config_file"
+}
+replace_magic_number cmi_magic_number "$cmi_magic_number"
+replace_magic_number ast_impl_magic_number "$ast_impl_magic_number"
+replace_magic_number ast_intf_magic_number "$ast_intf_magic_number"
+replace_magic_number cmt_magic_number "$cmt_magic_number"
+replace_magic_number cms_magic_number "$cms_magic_number"
+replace_magic_number index_magic_number "$index_magic_number"
+
+# After updating magic numbers, check that all strings in $target_config_file are one of
+# the above magic numbers (or some other known string). This helps ensure that there were
+# not any new magic numbers added that this script does not know about.
+okay_strings=".mli|$cmi_magic_number|$ast_impl_magic_number|$ast_intf_magic_number|$cmt_magic_number|$cms_magic_number|$index_magic_number"
+regex='"(?!'"$okay_strings"')[^"]*"'
+if grep -q -P "$regex" "$target_config_file"; then
+  echo "Warning: There may be new magic numbers in $target_config_file that were not updated:" >&2
+  grep -P "$regex" "$target_config_file" >&2
+fi


### PR DESCRIPTION
Add a new script that will bump the magic numbers.

Running this script will:
1. Verify that the git workspace is clean
2. Update the magic numbers in `src/ocaml/utils/config.ml`
3. Add a new entry in `src/ocaml/typing/magic_numbers.ml`

A test run of this script can be done by:
1. Find and replacing `551` with `552` in `upstream/ocaml_flambda/configure`.
2. Commit the above changes.
3. Running `./update-magic-numbers.sh 5.2.0minus-2`

I've performed a few test runs of this script, where:
- All magic numbers changed
- Some magic numbers changed
- No magic numbers changed
- The git workspace is unclean
- There was already an entry in `src/ocaml/typing/magic_numbers.ml`
- The magic numbers in `upstream/ocaml_flambda/configure` are not the expected format
- A new magic number has been added to `src/ocaml/utils/config.ml` that the script doesn't know about