### PR TITLE
Ignore `none` locations instead of ghost locations

### DIFF
--- a/src/analysis/ast_iterators.ml
+++ b/src/analysis/ast_iterators.ml
@@ -162,6 +162,8 @@ let iter_on_usages ~f (local_defs : Mtyper.typedtree) =
     | `Implementation structure -> iter.structure iter structure
   end
 
-let iterator_on_usages ~f =
+let iterator_on_usages ~include_hidden ~f =
   let occ_iter = Cmt_format.iter_on_occurrences ~f in
-  iter_only_visible occ_iter
+  match include_hidden with
+  | false -> iter_only_visible occ_iter
+  | true -> occ_iter

--- a/src/analysis/index_occurrences.ml
+++ b/src/analysis/index_occurrences.ml
@@ -26,6 +26,16 @@ let decl_of_path_or_lid env namespace path lid =
   | _ -> Env_lookup.by_path path namespace env
 
 let should_ignore_lid (lid : Longident.t Location.loc) =
+  (* Ignore occurrence if the location of the identifier is "none" because there is not a
+     useful location to report to the user. This can occur when the occurrence is in ppx
+     generated code and the ppx does not give location information.
+
+     An alternative implementation could instead ignore the occurrence if the location is
+     marked as "ghost". However, this seems too aggressive for two reasons:
+      - The expression being bound in a punned let expression is marked as ghost
+      - Ppx-generated code is often "ghost", but occurrences within ppx-generated code may
+        be useful
+  *)
   Location.is_none lid.loc
 
 let iterator ~current_buffer_path ~index ~stamp ~reduce_for_uid =

--- a/src/analysis/index_occurrences.ml
+++ b/src/analysis/index_occurrences.ml
@@ -81,7 +81,7 @@ let iterator ~current_buffer_path ~index ~stamp ~reduce_for_uid =
             index_decl ()
         end
   in
-  Ast_iterators.iterator_on_usages ~f
+  Ast_iterators.iterator_on_usages ~include_hidden:true ~f
 
 let items ~index ~stamp (config : Mconfig.t) items =
   let module Shape_reduce = Shape_reduce.Make (struct

--- a/tests/test-dirs/let-punning.t/run.t
+++ b/tests/test-dirs/let-punning.t/run.t
@@ -248,8 +248,6 @@ Test that finding occurrences of a variable includes usages in a punned let. i.e
 finding occurrences of x on line 1 returns the definition on line 1 and the usage on
 line 2.
 
-TODO: fix these tests
-
 let*
   $ occurrences 12:8
   Occurrences of:
@@ -258,6 +256,9 @@ let*
   Occurrence at 12:8-9:
       let a = return 1 in
           ^
+  Occurrence at 13:9-10:
+      let* a in
+           ^
 
 parallel let*
   $ occurrences 18:8
@@ -267,6 +268,9 @@ parallel let*
   Occurrence at 18:8-9:
       let a = return 1 in
           ^
+  Occurrence at 20:9-10:
+      let* a and* b in
+           ^
   $ occurrences 19:8
   Occurrences of:
       let b = return 1 in
@@ -274,6 +278,9 @@ parallel let*
   Occurrence at 19:8-9:
       let b = return 1 in
           ^
+  Occurrence at 20:16-17:
+      let* a and* b in
+                  ^
 
 sequential let*
   $ occurrences 25:8
@@ -283,6 +290,9 @@ sequential let*
   Occurrence at 25:8-9:
       let a = return 1 in
           ^
+  Occurrence at 27:9-10:
+      let* a in
+           ^
   $ occurrences 26:8
   Occurrences of:
       let b = return 1 in
@@ -290,3 +300,6 @@ sequential let*
   Occurrence at 26:8-9:
       let b = return 1 in
           ^
+  Occurrence at 28:9-10:
+      let* b in
+           ^

--- a/tests/test-dirs/occurrences/issue827.t/run.t
+++ b/tests/test-dirs/occurrences/issue827.t/run.t
@@ -17,7 +17,7 @@ Reproduction case:
       {
         "start": {
           "line": 4,
-          "col": 10
+          "col": 8
         },
         "end": {
           "line": 4,
@@ -76,7 +76,7 @@ work:
       {
         "start": {
           "line": 4,
-          "col": 10
+          "col": 8
         },
         "end": {
           "line": 4,

--- a/tests/test-dirs/occurrences/lid-locs.t
+++ b/tests/test-dirs/occurrences/lid-locs.t
@@ -30,7 +30,7 @@ The parenthesis are typed as an open statement
       {
         "start": {
           "line": 4,
-          "col": 10
+          "col": 8
         },
         "end": {
           "line": 4,
@@ -40,7 +40,7 @@ The parenthesis are typed as an open statement
       {
         "start": {
           "line": 5,
-          "col": 11
+          "col": 8
         },
         "end": {
           "line": 5,
@@ -69,8 +69,8 @@ The parenthesis are typed as an open statement
       },
       {
         "start": {
-          "line": 9,
-          "col": 2
+          "line": 8,
+          "col": 8
         },
         "end": {
           "line": 9,

--- a/tests/test-dirs/occurrences/mod-in-path-2.t
+++ b/tests/test-dirs/occurrences/mod-in-path-2.t
@@ -39,7 +39,7 @@ FIXME: we could expect module appearing in paths to be highlighted
     {
       "start": {
         "line": 5,
-        "col": 12
+        "col": 8
       },
       "end": {
         "line": 5,
@@ -49,7 +49,7 @@ FIXME: we could expect module appearing in paths to be highlighted
     {
       "start": {
         "line": 6,
-        "col": 8
+        "col": 4
       },
       "end": {
         "line": 6,

--- a/tests/test-dirs/occurrences/mod-in-path-3.t
+++ b/tests/test-dirs/occurrences/mod-in-path-3.t
@@ -40,7 +40,7 @@ FIXME: we could expect module appearing in paths to be highlighted
     {
       "start": {
         "line": 4,
-        "col": 12
+        "col": 8
       },
       "end": {
         "line": 4,
@@ -50,7 +50,7 @@ FIXME: we could expect module appearing in paths to be highlighted
     {
       "start": {
         "line": 7,
-        "col": 8
+        "col": 4
       },
       "end": {
         "line": 7,

--- a/tests/test-dirs/occurrences/project-wide/prefix.t/run.t
+++ b/tests/test-dirs/occurrences/project-wide/prefix.t/run.t
@@ -98,7 +98,7 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "file": "$TESTCASE_ROOT/a.ml",
         "start": {
           "line": 1,
-          "col": 12
+          "col": 10
         },
         "end": {
           "line": 1,
@@ -109,7 +109,7 @@ Merlin successfully finds occurrences outside file when UNIT_NAME directive is u
         "file": "$TESTCASE_ROOT/a.ml",
         "start": {
           "line": 2,
-          "col": 18
+          "col": 16
         },
         "end": {
           "line": 2,
@@ -157,7 +157,7 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "file": "$TESTCASE_ROOT/a.ml",
         "start": {
           "line": 1,
-          "col": 12
+          "col": 10
         },
         "end": {
           "line": 1,
@@ -168,7 +168,7 @@ Merlin successfully finds occurrences outside file when WRAPPING_PREFIX directiv
         "file": "$TESTCASE_ROOT/a.ml",
         "start": {
           "line": 2,
-          "col": 18
+          "col": 16
         },
         "end": {
           "line": 2,

--- a/tests/test-dirs/occurrences/project-wide/punning.t/definitions.ml
+++ b/tests/test-dirs/occurrences/project-wide/punning.t/definitions.ml
@@ -1,0 +1,4 @@
+let a = Some 1
+
+type t = { value : string }
+let value = "hello"

--- a/tests/test-dirs/occurrences/project-wide/punning.t/run.t
+++ b/tests/test-dirs/occurrences/project-wide/punning.t/run.t
@@ -1,0 +1,48 @@
+Test project-wide occurrences in the presence of punning (both let and record punning)
+
+Compile project, create index file, and configure Merlin to use index file
+  $ $OCAMLC -bin-annot -bin-annot-occurrences -c definitions.ml usages.ml
+  $ ocaml-index aggregate definitions.cmt usages.cmt
+  $ cat > .merlin << EOF
+  > INDEX project.ocaml-index
+  > EOF
+
+Convenience function for querying occurrences
+  $ occurrences () {
+  >   file="$1"
+  >   location="$2"
+  >   $MERLIN single occurrences -scope project -identifier-at "$location" -filename "$file" < "$file" | \
+  >     jq -r '.value[] | "\(.file) \(.start.line):\(.start.col)-\(.end.col)"'
+  > }
+
+Get occurrences of an identifier that is used as the expression part of a punned let
+expression
+FIXME: this should also include the occurrence on line 6 of usages.ml
+  $ occurrences definitions.ml 1:4
+  $TESTCASE_ROOT/definitions.ml 1:4-5
+
+Get occurrences, with the cursor pointing at the identifier in a punned let.
+Merlin returns the occurrences of the new variable bound in that let, rather than the
+expression being assigned to the variable.
+  $ occurrences usages.ml 6:7
+  $TESTCASE_ROOT/usages.ml 6:7-8
+  $TESTCASE_ROOT/usages.ml 7:7-8
+
+Get occurrences of a record field, where there is an instance of punning that field while
+creating a record
+  $ occurrences definitions.ml 3:13
+  $TESTCASE_ROOT/definitions.ml 3:11-16
+  $TESTCASE_ROOT/usages.ml 10:10-15
+
+Get occurrences of a variable that is used as the value being placed into a record in a
+punned record field expression
+  $ occurrences definitions.ml 4:6
+  $TESTCASE_ROOT/definitions.ml 4:4-9
+  $TESTCASE_ROOT/usages.ml 10:10-15
+
+Get occurrences, with the cursor pointing at a punned record field expression.
+Merlin finds occurrences of the value being placed into the record rather than the record
+field
+  $ occurrences usages.ml 10:12
+  $TESTCASE_ROOT/definitions.ml 4:4-9
+  $TESTCASE_ROOT/usages.ml 10:10-15

--- a/tests/test-dirs/occurrences/project-wide/punning.t/usages.ml
+++ b/tests/test-dirs/occurrences/project-wide/punning.t/usages.ml
@@ -1,0 +1,10 @@
+include Definitions
+
+(* Let punning *)
+let _ =
+  let (let*) = Option.bind in
+  let* a in
+  Some a
+
+(* Record field punning *)
+let _ = { value }

--- a/tests/test-dirs/occurrences/project-wide/pwo-basic.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-basic.t
@@ -53,7 +53,7 @@
         "file": "$TESTCASE_ROOT/main.ml",
         "start": {
           "line": 1,
-          "col": 26
+          "col": 22
         },
         "end": {
           "line": 1,

--- a/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-canonicalize.t
@@ -44,7 +44,7 @@
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {
         "line": 1,
-        "col": 26
+        "col": 22
       },
       "end": {
         "line": 1,

--- a/tests/test-dirs/occurrences/project-wide/pwo-relative.t
+++ b/tests/test-dirs/occurrences/project-wide/pwo-relative.t
@@ -74,7 +74,7 @@ Perform the occurrences query
       "file": "$TESTCASE_ROOT/main/main.ml",
       "start": {
         "line": 1,
-        "col": 12
+        "col": 8
       },
       "end": {
         "line": 1,
@@ -85,7 +85,7 @@ Perform the occurrences query
       "file": "$TESTCASE_ROOT/main/main.ml",
       "start": {
         "line": 2,
-        "col": 26
+        "col": 22
       },
       "end": {
         "line": 2,

--- a/tests/test-dirs/occurrences/punning.t/run.t
+++ b/tests/test-dirs/occurrences/punning.t/run.t
@@ -1,0 +1,45 @@
+Test occurrences in the presence of punning (both let and record punning)
+
+Convenience function for querying occurrences
+  $ occurrences () {
+  >   location="$1"
+  >   $MERLIN single occurrences -identifier-at "$location" -filename test.ml < test.ml | \
+  >     jq -r '.value[] | "\(.start.line):\(.start.col)-\(.end.col)"'
+  > }
+
+Get occurrences of an identifier that is used as the expression part of a punned let
+expression
+FIXME: this should also include the occurrence on line 5
+  $ occurrences 4:6
+  4:6-7
+
+Get occurrences, with the cursor pointing at the identifier in a punned let.
+Merlin returns the occurrences of the new variable bound in that let, rather than the
+expression being assigned to the variable.
+  $ occurrences 5:7
+  5:7-8
+  6:7-8
+
+Get occurrences of an identifier that was defined in a punned let expression
+  $ occurrences 5:7
+  5:7-8
+  6:7-8
+
+Get occurrences of a record field, where there is an instance of punning that field while
+creating a record
+  $ occurrences 9:13
+  9:11-16
+  11:10-15
+
+Get occurrences of a variable that is used as the value being placed into a record in a
+punned record field expression
+  $ occurrences 10:4
+  10:4-9
+  11:10-15
+
+Get occurrences, with the cursor pointing at a punned record field expression.
+Merlin finds occurrences of the value being placed into the record rather than the record
+field
+  $ occurrences 10:4
+  10:4-9
+  11:10-15

--- a/tests/test-dirs/occurrences/punning.t/run.t
+++ b/tests/test-dirs/occurrences/punning.t/run.t
@@ -9,9 +9,9 @@ Convenience function for querying occurrences
 
 Get occurrences of an identifier that is used as the expression part of a punned let
 expression
-FIXME: this should also include the occurrence on line 5
   $ occurrences 4:6
   4:6-7
+  5:7-8
 
 Get occurrences, with the cursor pointing at the identifier in a punned let.
 Merlin returns the occurrences of the new variable bound in that let, rather than the

--- a/tests/test-dirs/occurrences/punning.t/test.ml
+++ b/tests/test-dirs/occurrences/punning.t/test.ml
@@ -1,0 +1,11 @@
+(* Let punning *)
+let _ =
+  let (let*) = Option.bind in
+  let a = Some 1 in
+  let* a in
+  Some a
+
+(* Record field punning *)
+type t = { value : string }
+let value = "hello"
+let _ = { value }

--- a/tests/test-dirs/server-tests/pwo-uid-stability.t
+++ b/tests/test-dirs/server-tests/pwo-uid-stability.t
@@ -40,7 +40,7 @@
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {
         "line": 1,
-        "col": 13
+        "col": 9
       },
       "end": {
         "line": 1,
@@ -87,7 +87,7 @@ We are not missing the occurrence in main.ml
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {
         "line": 1,
-        "col": 13
+        "col": 9
       },
       "end": {
         "line": 1,
@@ -132,7 +132,7 @@ We are not missing the occurrence in main.ml
       "file": "$TESTCASE_ROOT/main.ml",
       "start": {
         "line": 1,
-        "col": 13
+        "col": 9
       },
       "end": {
         "line": 1,


### PR DESCRIPTION
Currently, the occurrences query ignores identifiers if their location is "ghost". This causes issues with finding occurrences in the presence of let punning. Also, this probably produces some undesirable behavior in the presence of ppxs (occurrences within ppx-generated code will be ignored). This PR changes occurrences to instead ignore identifiers whose location is `Location.none`.

This PR also causes the occurrences query to begin filtering occurrences read from an index file. This goes in hand with [this flambda PR](https://github.com/ocaml-flambda/flambda-backend/pull/3137), which causes occurrences in cmt/cms files to not be pre-filtered. Before, flambda also filtered "ghost" locations when producing cmt/cms files. Now, it will do no filtering, leaving the onus on Merlin.

Because of this, one of the tests introduced by this PR is left unfixed - it will be corrected once the flambda PR is merged. I've made a separate draft PR (#109) that contains the changes from this PR, but it is based on the flambda version that contains the relevant patch. In that draft PR, the test is corrected and passing.