### PR TITLE
Make more compatible with opam

### DIFF
--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -21,6 +21,7 @@
   -open Merlin_analysis
   -open Merlin_kernel)
  (libraries
+  merlin_extend
   merlin_utils
   merlin_kernel
   ocaml_utils

--- a/src/ocaml/compression/dune
+++ b/src/ocaml/compression/dune
@@ -1,4 +1,0 @@
-(library
- (name ocaml_compression)
- (public_name merlin-lib.ocaml_compression)
- (libraries compiler-libs.common))

--- a/src/ocaml/compression/ocaml_compression.ml
+++ b/src/ocaml/compression/ocaml_compression.ml
@@ -1,3 +1,0 @@
-
-(** We rely on [compiler-libs] for compression *)
-include Compression

--- a/src/ocaml/typing/dune
+++ b/src/ocaml/typing/dune
@@ -7,4 +7,4 @@
    -open Merlin_utils
    (:standard -w -9))
   (modules_without_implementation annot outcometree mode_intf solver_intf value_rec_types)
-  (libraries merlin_utils ocaml_compression ocaml_parsing ocaml_utils))
+  (libraries merlin_utils ocaml_parsing ocaml_utils))


### PR DESCRIPTION
Make more compatible with the bleeding-edge-with-extensions opam switch:
  * delete the `Compression` module which isn't used
  * fix a missing dependency &mdash; I'm not sure why this doesn't affect the local build