### PR TITLE
Add params to ignore

### DIFF
--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -614,7 +614,14 @@ let ocaml_ignored_flags =
     "-dvectorize";
     "-dump-into-csv";
     "-cfg-selection";
-    "-no-cfg-selection"
+    "-no-cfg-selection";
+    "-no-mach-ir";
+    "-flambda2-reaper";
+    "-no-flambda2-reaper";
+    "-dsimplify";
+    "-dreaper";
+    "-instantiate";
+    "-dflambda-heavy-invariants"
   ]
 
 let ocaml_ignored_parametrized_flags =
@@ -682,7 +689,8 @@ let ocaml_ignored_parametrized_flags =
     "-cfg-stack-checks-threshold";
     "-zero-alloc-checker-details-cutoff";
     "-zero-alloc-checker-join";
-    "-dgranularity"
+    "-dgranularity";
+    "-flambda2-expert-cont-lifting-budget"
   ]
 
 let ocaml_warnings_spec ~error =


### PR DESCRIPTION
I've mistakenly neglected adding new flambda parameters to Merlin's list of ignored flags the past few merges. Specifically, the 5.1.1minus-24 merge is the last one where I did not fail to do this. This PR adds all flags that were added to flambda between 5.1.1minus-24 and 5.2.0minus-4.