### PR TITLE
Move typed_hole from ocaml-lsp

### DIFF
--- a/src/analysis/typed_hole.ml
+++ b/src/analysis/typed_hole.ml
@@ -14,4 +14,3 @@ let is_a_hole = function
   | (_, Browse_raw.Module_expr { mod_desc = Tmod_typed_hole; _ }) :: (_, _) :: _
   | (_, Browse_raw.Expression { exp_desc = Texp_typed_hole; _ }) :: _ -> true
   | [] | (_, _) :: _ -> false
-;;

--- a/src/analysis/typed_hole.ml
+++ b/src/analysis/typed_hole.ml
@@ -1,0 +1,17 @@
+let syntax_repr = "_"
+let can_be_hole s = String.equal syntax_repr s
+
+(* the pattern matching below is taken and modified (minimally, to adapt the
+   return type) from [Query_commands.dispatch]'s [Construct] branch;
+
+   If we directly dispatched [Construct] command to merlin, we'd be doing
+   useless computations: we need info whether the expression at the cursor is a
+   hole, we don't need constructed expressions yet.
+
+   Ideally, merlin should return a callback [option], which is [Some] when the
+   context is applicable. *)
+let is_a_hole = function
+  | (_, Browse_raw.Module_expr { mod_desc = Tmod_typed_hole; _ }) :: (_, _) :: _
+  | (_, Browse_raw.Expression { exp_desc = Texp_typed_hole; _ }) :: _ -> true
+  | [] | (_, _) :: _ -> false
+;;

--- a/src/analysis/typed_hole.mli
+++ b/src/analysis/typed_hole.mli
@@ -1,0 +1,15 @@
+(** This module should be used to work with typed holes. The main goal is to
+    hide syntactic representation of a typed hole, which may change in future *)
+
+(** checks whether the current string matches the syntax representation of a
+    typed hole *)
+val can_be_hole : string -> bool
+
+(** [is_a_hole nodes] checks whether the leaf node [1] is a typed hole
+
+    Note: this function is extracted from merlin sources handling [Construct]
+    command in [merlin/src/frontend/query_commands.ml]
+
+    [1] leaf node is the head of the list, as
+    [Mbrowse.t = (Env.t * Browse_raw.node) list]*)
+val is_a_hole : Mbrowse.t -> bool


### PR DESCRIPTION
This change is backported from an upstream PR: https://github.com/ocaml/merlin/pull/1888. The rest of the changes in that PR are already in merlin-jst.