### PR TITLE
Adding tests for signature help with only labelled arguments

### DIFF
--- a/tests/test-dirs/signature-help/issue_labelled_args.t
+++ b/tests/test-dirs/signature-help/issue_labelled_args.t
@@ -1,0 +1,63 @@
+  $ $MERLIN single signature-help -position 2:14 << EOF
+  > let f ~x ~y = x + y
+  > let _ = 1 - f 
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : x:int -> y:int -> int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                9
+              ]
+            },
+            {
+              "label": [
+                13,
+                18
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+  $ $MERLIN single signature-help -position 2:19 << EOF
+  > let f ~x ~y = x + y
+  > let _ = 1 - f ~x:3 
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : x:int -> y:int -> int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                9
+              ]
+            },
+            {
+              "label": [
+                13,
+                18
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }


### PR DESCRIPTION
This PR adds a test to ensure the signature help for functions with only labelled arguments works.