### PR TITLE
Signature-help should trigger on unfinished `let ... in` bindings

### DIFF
--- a/tests/test-dirs/signature-help/issue_let_in_binding.t
+++ b/tests/test-dirs/signature-help/issue_let_in_binding.t
@@ -1,0 +1,20 @@
+  $ cat > test1.ml <<'EOF'
+  > let _ =
+  > let f = List.map   in
+  > let _ = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test1 < test1.ml | jq '.value.signatures[0].label'
+  "List.map : ('a -> 'b) -> 'a list -> 'b list"
+
+FIXME: Signature-help does not trigger on unfinished let ... in bindings.
+  $ cat > test2.ml <<'EOF'
+  > let _ =
+  > let f = List.map  
+  > let _ = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml | jq '.value.signatures[0].label'
+  null


### PR DESCRIPTION
Signature-help does not trigger on unfinished `let … in` bindings.
Nothing shows up if the `in` keyword is missing, and it works as expected if it is present.
This PR adds a test case to demonstrate this wrong behaviour, and a fix has been implemented in https://github.com/oxcaml/merlin/pull/223.