### PR TITLE
Signature help should suggest optional arguments

### DIFF
--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -6,7 +6,7 @@ type parameter_info =
   { label : Typedtree.arg_label;
     param_start : int;
     param_end : int;
-    argument : Typedtree.expression option
+    argument : Typedtree.apply_arg
   }
 
 type application_signature =
@@ -73,13 +73,21 @@ let pp_parameter env label ppf ty =
   | Position l -> Format.fprintf ppf "%s:[%%call_pos]" l
 
 (* record buffer offsets to be able to underline parameter types *)
-let print_parameter_offset ?arg:argument ppf buffer env label ty =
+let print_parameter_offset ~arg:argument ppf buffer env label ty =
   let param_start = Buffer.length buffer in
   Format.fprintf ppf "%a%!" (pp_parameter env label) ty;
   let param_end = Buffer.length buffer in
   Format.pp_print_string ppf " -> ";
   Format.pp_print_flush ppf ();
   { label; param_start; param_end; argument }
+
+let omitted : Typedtree.omitted_parameter =
+  let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
+  let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+  let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+  let sort_arg = Jkind.Sort.value in
+  let sort_ret = Jkind.Sort.value in
+  { mode_closure; mode_arg; mode_ret; sort_arg; sort_ret }
 
 (* This function preprocesses the signature and associate already assigned
    arguments to the corresponding parameter. (They should always be in the correct
@@ -91,17 +99,14 @@ let separate_function_signature ~args (e : Typedtree.expression) =
   let rec separate ?(parameters = []) args ty =
     match (args, Types.get_desc ty) with
     | (_l, arg) :: args, Tarrow ((label, _, _), ty1, ty2, _) ->
-      let arg =
-        match (arg : Typedtree.apply_arg) with
-        | Arg (arg, _) -> Some arg
-        | Omitted _ -> None
-      in
       let parameter =
-        print_parameter_offset ppf buffer e.exp_env label ty1 ?arg
+        print_parameter_offset ~arg ppf buffer e.exp_env label ty1
       in
       separate args ty2 ~parameters:(parameter :: parameters)
     | [], Tarrow ((label, _, _), ty1, ty2, _) ->
-      let parameter = print_parameter_offset ppf buffer e.exp_env label ty1 in
+      let parameter =
+        print_parameter_offset ~arg:(Omitted omitted) ppf buffer e.exp_env label ty1
+      in
       separate args ty2 ~parameters:(parameter :: parameters)
     (* end of function type, print remaining type without recording offsets *)
     | _ ->
@@ -117,18 +122,18 @@ let separate_function_signature ~args (e : Typedtree.expression) =
 
 let active_parameter_by_arg ~arg params =
   let find_by_arg = function
-    | { argument = Some a; _ } when a == arg -> true
+    | { argument = Arg (a, _); _ } when a == arg -> true
     | _ -> false
   in
   try Some (List.index params ~f:find_by_arg) with Not_found -> None
 
 let first_unassigned_argument params =
   let positional = function
-    | { argument = None; label = Typedtree.Nolabel; _ } -> true
+    | { argument = Omitted _; label = Typedtree.Nolabel; _ } -> true
     | _ -> false
   in
   let labelled = function
-    | { argument = None; label = Typedtree.Labelled _ | Optional _; _ } -> true
+    | { argument = Omitted _; label = Typedtree.Labelled _ | Optional _; _ } -> true
     | _ -> false
   in
   try Some (List.index params ~f:positional)

--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -105,7 +105,8 @@ let separate_function_signature ~args (e : Typedtree.expression) =
       separate args ty2 ~parameters:(parameter :: parameters)
     | [], Tarrow ((label, _, _), ty1, ty2, _) ->
       let parameter =
-        print_parameter_offset ~arg:(Omitted omitted) ppf buffer e.exp_env label ty1
+        print_parameter_offset ~arg:(Omitted omitted) ppf buffer e.exp_env label
+          ty1
       in
       separate args ty2 ~parameters:(parameter :: parameters)
     (* end of function type, print remaining type without recording offsets *)
@@ -133,7 +134,8 @@ let first_unassigned_argument params =
     | _ -> false
   in
   let labelled = function
-    | { argument = Omitted _; label = Typedtree.Labelled _ | Optional _; _ } -> true
+    | { argument = Omitted _; label = Typedtree.Labelled _ | Optional _; _ } ->
+      true
     | _ -> false
   in
   try Some (List.index params ~f:positional)
@@ -149,16 +151,21 @@ let active_parameter_by_prefix ~prefix params =
       Some (String.common_prefix_len (Btype.prefixed_label_name l) prefix)
     | _ -> None
   in
-
+  let is_omitted = function
+    | Typedtree.Omitted _ -> true
+    | _ -> false
+  in
   let rec find_by_prefix ?(i = 0) ?longest_len ?longest_i = function
     | [] -> longest_i
-    | p :: ps -> (
+    | p :: ps when is_omitted p.argument -> (
+      (* The search is performed only on the arguments not already given in the parameters. *)
       match (common p.label, longest_len) with
       | Some common_len, Some longest_len when common_len > longest_len ->
         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
       | Some common_len, None ->
         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
       | _ -> find_by_prefix ps ~i:(succ i) ?longest_len ?longest_i)
+    | _ :: ps -> find_by_prefix ps ~i:(succ i) ?longest_len ?longest_i
   in
   find_by_prefix params
 

--- a/src/analysis/signature_help.mli
+++ b/src/analysis/signature_help.mli
@@ -2,7 +2,7 @@ type parameter_info =
   { label : Typedtree.arg_label;
     param_start : int;
     param_end : int;
-    argument : Typedtree.expression option
+    argument : Typedtree.apply_arg
   }
 
 type application_signature =

--- a/tests/test-dirs/signature-help/issue_optional_args.t
+++ b/tests/test-dirs/signature-help/issue_optional_args.t
@@ -1,0 +1,256 @@
+FIXME: Active parameter should be 1 because x is already written
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ~ 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> ?y:'_weak1 -> x:int -> '_weak2 -> int * '_weak1 option * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                30
+              ]
+            },
+            {
+              "label": [
+                34,
+                41
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 2,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after the `?`. There is only one optional parameter so the active parameter is y.
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ? 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> ?y:'_weak1 -> x:int -> '_weak2 -> int * '_weak1 option * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                30
+              ]
+            },
+            {
+              "label": [
+                34,
+                41
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+This test is valid because `~y` is a complete parameter.
+  $ $MERLIN single signature-help -position 2:18 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ~y 1
+  > EOF
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is at the end of the second line. The function is waiting for a last labelled argument and it is `y`.
+  $ $MERLIN single signature-help -position 2:20 << EOF
+  > let f a ~x ~y t = (a, y, x, t)
+  > let _ = f 1 ~x:43 1 
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> x:int -> y:'_weak1 -> int -> int * '_weak1 * int * int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                16
+              ]
+            },
+            {
+              "label": [
+                20,
+                29
+              ]
+            },
+            {
+              "label": [
+                33,
+                36
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 2,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+FIXME: Active parameter should be 2
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ~x ~y t = (a, y, x, t)
+  > let _ = f ~x:43 ~ 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> x:int -> y:'_weak1 -> '_weak2 -> int * '_weak1 * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                16
+              ]
+            },
+            {
+              "label": [
+                20,
+                29
+              ]
+            },
+            {
+              "label": [
+                33,
+                40
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after `~`. As `f` is already given in the expression, signature help waits for the next parameter as `~f` is a valid parameter.
+  $ $MERLIN single signature-help -position 2:13 <<EOF
+  > let map = ListLabels.map
+  > let _ = map ~f:Int.abs
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "map : f:(int -> int) -> int list -> int list",
+          "parameters": [
+            {
+              "label": [
+                6,
+                20
+              ]
+            },
+            {
+              "label": [
+                24,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after `~`. As `f` isn't already given in the expression, signature help waits for the value of `~f`.
+  $ $MERLIN single signature-help -position 2:13 <<EOF
+  > let map = ListLabels.map
+  > let _ = map ~
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "map : f:('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                6,
+                18
+              ]
+            },
+            {
+              "label": [
+                22,
+                29
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/signature-help/issue_optional_args.t
+++ b/tests/test-dirs/signature-help/issue_optional_args.t
@@ -1,4 +1,4 @@
-FIXME: Active parameter should be 1 because x is already written
+The cursor is after the second `~`. As `~x` has already been written, the active parameter is `y`.
   $ $MERLIN single signature-help -position 2:17 << EOF
   > let f a ?y ~x t = (a, y, x, t)
   > let _ = f ~x:43 ~ 1
@@ -37,7 +37,7 @@ FIXME: Active parameter should be 1 because x is already written
           ]
         }
       ],
-      "activeParameter": 2,
+      "activeParameter": 1,
       "activeSignature": 0
     },
     "notifications": []
@@ -144,7 +144,7 @@ The cursor is at the end of the second line. The function is waiting for a last 
     "notifications": []
   }
 
-FIXME: Active parameter should be 2
+The cursor is after the second `~`. As `~x` has already been written, the active parameter is `y`.
   $ $MERLIN single signature-help -position 2:17 << EOF
   > let f a ~x ~y t = (a, y, x, t)
   > let _ = f ~x:43 ~ 1
@@ -183,7 +183,7 @@ FIXME: Active parameter should be 2
           ]
         }
       ],
-      "activeParameter": 1,
+      "activeParameter": 2,
       "activeSignature": 0
     },
     "notifications": []

--- a/tests/test-dirs/signature-help/signature-help.t
+++ b/tests/test-dirs/signature-help/signature-help.t
@@ -127,8 +127,9 @@ It can make the non-labelled parameter active.
     "notifications": []
   }
 
-It can make the labelled parameter active.
-  $ $MERLIN single signature-help -position 2:14 <<EOF
+The cursor is after `:`. As `~f:` isn't a valid parameter, signature help waits for the value of `~f`.
+FIXME we could expect signature help to show the correct parameter with the cursor before the : too
+  $ $MERLIN single signature-help -position 2:15 <<EOF
   > let map = ListLabels.map
   > let _ = map ~f:Int.abs
   > EOF


### PR DESCRIPTION
When a labelled argument is initiated, signature-help always displays the first labelled argument in the signature, even if it has already been written.
A hierarchy is processed: the list of arguments is first the labelled ones, then the optional ones.
As it always takes the first one, no matter what has already been written, optional arguments are never highlighted, even if they are initiated with a `~`.

In the following example, the cursor is after the second `~` on line 2.
Signature-help should set `y` as the active parameter, since `x` is already written, but it still highlights `x`.
```ocaml
let f a ~x ~y t = (a, y, x, t)
let _ = f ~x:43 ~ 1
```

This PR fixes this wrong behaviour and downstreams it from https://github.com/ocaml/merlin/pull/2032.