### PR TITLE
Fixing the issue on `let..in` binding on signature help

### DIFF
--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -6,7 +6,7 @@ type parameter_info =
   { label : Typedtree.arg_label;
     param_start : int;
     param_end : int;
-    argument : Typedtree.expression option
+    argument : Typedtree.apply_arg
   }
 
 type application_signature =
@@ -73,13 +73,21 @@ let pp_parameter env label ppf ty =
   | Position l -> Format.fprintf ppf "%s:[%%call_pos]" l
 
 (* record buffer offsets to be able to underline parameter types *)
-let print_parameter_offset ?arg:argument ppf buffer env label ty =
+let print_parameter_offset ~arg:argument ppf buffer env label ty =
   let param_start = Buffer.length buffer in
   Format.fprintf ppf "%a%!" (pp_parameter env label) ty;
   let param_end = Buffer.length buffer in
   Format.pp_print_string ppf " -> ";
   Format.pp_print_flush ppf ();
   { label; param_start; param_end; argument }
+
+let omitted : Typedtree.omitted_parameter =
+  let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
+  let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+  let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+  let sort_arg = Jkind.Sort.value in
+  let sort_ret = Jkind.Sort.value in
+  { mode_closure; mode_arg; mode_ret; sort_arg; sort_ret }
 
 (* This function preprocesses the signature and associate already assigned
    arguments to the corresponding parameter. (They should always be in the correct
@@ -91,17 +99,15 @@ let separate_function_signature ~args (e : Typedtree.expression) =
   let rec separate ?(parameters = []) args ty =
     match (args, Types.get_desc ty) with
     | (_l, arg) :: args, Tarrow ((label, _, _), ty1, ty2, _) ->
-      let arg =
-        match (arg : Typedtree.apply_arg) with
-        | Arg (arg, _) -> Some arg
-        | Omitted _ -> None
-      in
       let parameter =
-        print_parameter_offset ppf buffer e.exp_env label ty1 ?arg
+        print_parameter_offset ~arg ppf buffer e.exp_env label ty1
       in
       separate args ty2 ~parameters:(parameter :: parameters)
     | [], Tarrow ((label, _, _), ty1, ty2, _) ->
-      let parameter = print_parameter_offset ppf buffer e.exp_env label ty1 in
+      let parameter =
+        print_parameter_offset ~arg:(Omitted omitted) ppf buffer e.exp_env label
+          ty1
+      in
       separate args ty2 ~parameters:(parameter :: parameters)
     (* end of function type, print remaining type without recording offsets *)
     | _ ->
@@ -117,18 +123,19 @@ let separate_function_signature ~args (e : Typedtree.expression) =
 
 let active_parameter_by_arg ~arg params =
   let find_by_arg = function
-    | { argument = Some a; _ } when a == arg -> true
+    | { argument = Arg (a, _); _ } when a == arg -> true
     | _ -> false
   in
   try Some (List.index params ~f:find_by_arg) with Not_found -> None
 
 let first_unassigned_argument params =
   let positional = function
-    | { argument = None; label = Typedtree.Nolabel; _ } -> true
+    | { argument = Omitted _; label = Typedtree.Nolabel; _ } -> true
     | _ -> false
   in
   let labelled = function
-    | { argument = None; label = Typedtree.Labelled _ | Optional _; _ } -> true
+    | { argument = Omitted _; label = Typedtree.Labelled _ | Optional _; _ } ->
+      true
     | _ -> false
   in
   try Some (List.index params ~f:positional)

--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -162,7 +162,8 @@ let is_arrow t =
   | Tarrow _ -> true
   | _ -> false
 
-let application_signature ~prefix ~cursor = function
+let application_signature ~prefix ~cursor node =
+  match node with
   | (_, Browse_raw.Expression arg)
     :: ( _,
          Expression
@@ -195,7 +196,54 @@ let application_signature ~prefix ~cursor = function
     let result = separate_function_signature e ~args:[] in
     let active_param = active_parameter_by_prefix ~prefix result.parameters in
     Some { result with active_param }
-  | _ -> None
+  | _ ->
+    let rec find_smallest_arrow_before_pos (e : Typedtree.expression) pos
+        ~(acc : Typedtree.expression) =
+      if Lexing.compare_pos e.exp_loc.loc_start pos = 1 then
+        match acc.exp_desc with
+        | Texp_let (_, vlist, _) ->
+          let v =
+            List.find_opt
+              ~f:(fun (value_binding : Typedtree.value_binding) ->
+                match Types.get_desc value_binding.vb_expr.exp_type with
+                | Tarrow _ -> true
+                | _ -> false)
+              vlist
+          in
+          Option.map ~f:(fun (v : Typedtree.value_binding) -> v.vb_expr) v
+        | _ -> None
+      else
+        match e.exp_desc with
+        | Texp_let (_, _, next) ->
+          find_smallest_arrow_before_pos next pos ~acc:e
+        | _ -> None
+    in
+    let f node cursor =
+      match node with
+      | _, Browse_raw.Expression e ->
+        find_smallest_arrow_before_pos e cursor ~acc:e
+      | _ -> assert false
+    in
+    let expressions =
+      List.filter
+        ~f:(fun n ->
+          match n with
+          | _, Browse_raw.Expression _ -> true
+          | _ -> false)
+        node
+    in
+    if expressions = [] then None
+    else
+      let last_node = List.hd (List.rev expressions) in
+      let smallest_frag_opt = f last_node cursor in
+      Option.map
+        ~f:(fun frag ->
+          let result = separate_function_signature frag ~args:[] in
+          let active_param =
+            active_parameter_by_prefix ~prefix result.parameters
+          in
+          { result with active_param })
+        smallest_frag_opt
 
 let prefix_of_position ~short_path source position =
   match Msource.text source with

--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -145,15 +145,22 @@ let active_parameter_by_prefix ~prefix params =
     | _ -> None
   in
 
+  let is_omitted = function
+    | Typedtree.Omitted _ -> true
+    | _ -> false
+  in
+
   let rec find_by_prefix ?(i = 0) ?longest_len ?longest_i = function
     | [] -> longest_i
-    | p :: ps -> (
+    | p :: ps when is_omitted p.argument -> (
+      (* The search is performed only on the arguments not already given in the parameters. *)
       match (common p.label, longest_len) with
       | Some common_len, Some longest_len when common_len > longest_len ->
         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
       | Some common_len, None ->
         find_by_prefix ps ~i:(succ i) ~longest_len:common_len ~longest_i:i
       | _ -> find_by_prefix ps ~i:(succ i) ?longest_len ?longest_i)
+    | _ :: ps -> find_by_prefix ps ~i:(succ i) ?longest_len ?longest_i
   in
   find_by_prefix params
 
@@ -198,8 +205,8 @@ let application_signature ~prefix ~cursor node =
     Some { result with active_param }
   | _ ->
     let rec find_smallest_arrow_before_pos (e : Typedtree.expression) pos
-        ~(acc : Typedtree.expression) =
-      if Lexing.compare_pos e.exp_loc.loc_start pos = 1 then
+        (acc : Typedtree.expression) =
+      if Lexing.compare_pos e.exp_loc.loc_start pos > 0 then
         match acc.exp_desc with
         | Texp_let (_, vlist, _) ->
           let v =
@@ -214,28 +221,23 @@ let application_signature ~prefix ~cursor node =
         | _ -> None
       else
         match e.exp_desc with
-        | Texp_let (_, _, next) ->
-          find_smallest_arrow_before_pos next pos ~acc:e
+        | Texp_let (_, _, next) -> find_smallest_arrow_before_pos next pos e
         | _ -> None
     in
-    let f node cursor =
-      match node with
-      | _, Browse_raw.Expression e ->
-        find_smallest_arrow_before_pos e cursor ~acc:e
-      | _ -> assert false
-    in
     let expressions =
-      List.filter
+      List.filter_map
         ~f:(fun n ->
           match n with
-          | _, Browse_raw.Expression _ -> true
-          | _ -> false)
+          | _, Browse_raw.Expression e -> Some e
+          | _ -> None)
         node
     in
     if expressions = [] then None
     else
       let last_node = List.hd (List.rev expressions) in
-      let smallest_frag_opt = f last_node cursor in
+      let smallest_frag_opt =
+        find_smallest_arrow_before_pos last_node cursor last_node
+      in
       Option.map
         ~f:(fun frag ->
           let result = separate_function_signature frag ~args:[] in

--- a/src/analysis/signature_help.mli
+++ b/src/analysis/signature_help.mli
@@ -2,7 +2,7 @@ type parameter_info =
   { label : Typedtree.arg_label;
     param_start : int;
     param_end : int;
-    argument : Typedtree.expression option
+    argument : Typedtree.apply_arg
   }
 
 type application_signature =

--- a/tests/test-dirs/signature-help/issue_let_in_binding.t
+++ b/tests/test-dirs/signature-help/issue_let_in_binding.t
@@ -9,7 +9,7 @@ The cursor is between 'map' and 'in' and behaves correctly as the in is written.
   $ $MERLIN single signature-help -position 2:17 -filename test1 < test1.ml | jq '.value.signatures[0].label'
   "List.map : ('a -> 'b) -> 'a list -> 'b list"
 
-FIXME: The cursor is after the map, but without the 'in', signature help is not triggered.
+The cursor is after the map and triggers the 'map' signature help.
   $ cat > test2.ml <<'EOF'
   > let _ =
   > let f = List.map  
@@ -18,9 +18,9 @@ FIXME: The cursor is after the map, but without the 'in', signature help is not 
   > EOF
 
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml | jq '.value.signatures[0].label'
-  null
+  "List.map : ('a -> 'b) -> 'a list -> 'b list"
 
-FIXME: The cursor is after 'map' and should trigger signature help for the function 'map'.
+The cursor is after 'map' and triggers correctly signature help for the function 'map'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -30,7 +30,29 @@ FIXME: The cursor is after 'map' and should trigger signature help for the funct
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
@@ -109,7 +131,7 @@ The cursor is between 'map' and 'in' and triggers correctly the 'map' even if th
     "notifications": []
   }
 
-FIXME: The cursor is after 'map' and should trigger the 'map'
+The cursor is after 'map' and triggers correctly the 'map'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -121,11 +143,33 @@ FIXME: The cursor is after 'map' and should trigger the 'map'
   $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
-FIXME: The cursor is after the '()' of the 'iter' function. It should trigger the 'iter' with active parameter set to 1.
+FIXME: The cursor is after the '()' of the 'iter' function. It triggers the function from the parenthesis but should trigger the 'iter' with active parameter set to 1.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -136,11 +180,27 @@ FIXME: The cursor is after the '()' of the 'iter' function. It should trigger th
   $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "_ : 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                4,
+                11
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
-FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
+The cursor is after the 'iter' and trigger correcly the 'iter'.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.map 
@@ -151,7 +211,29 @@ FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
   $ $MERLIN single signature-help -position 3:18 -filename test2 < test2.ml
   {
     "class": "return",
-    "value": {},
+    "value": {
+      "signatures": [
+        {
+          "label": "List.iter : ('a -> unit) -> 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                12,
+                24
+              ]
+            },
+            {
+              "label": [
+                28,
+                35
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
     "notifications": []
   }
 
@@ -192,7 +274,7 @@ The cursor is between the '()' and 'in' and triggers correctly the 'iter' signat
     "notifications": []
   }
 
-The cursor is after the 'in' of the 'let n = 5 in' and triggers nothing.
+The cursor is after the 'in' of the 'let n = 5 in' and triggers correctly nothing.
   $ cat > test2.ml <<'EOF'
   > let g =
   > let f = List.hd in

--- a/tests/test-dirs/signature-help/issue_let_in_binding.t
+++ b/tests/test-dirs/signature-help/issue_let_in_binding.t
@@ -1,0 +1,209 @@
+The cursor is between 'map' and 'in' and behaves correctly as the in is written.
+  $ cat > test1.ml <<'EOF'
+  > let _ =
+  > let f = List.map   in
+  > let _ = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test1 < test1.ml | jq '.value.signatures[0].label'
+  "List.map : ('a -> 'b) -> 'a list -> 'b list"
+
+FIXME: The cursor is after the map, but without the 'in', signature help is not triggered.
+  $ cat > test2.ml <<'EOF'
+  > let _ =
+  > let f = List.map  
+  > let _ = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml | jq '.value.signatures[0].label'
+  null
+
+FIXME: The cursor is after 'map' and should trigger signature help for the function 'map'.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is after the 'ends_with' function and triggers the signature help.
+FIXME: The active parameter should be 0.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map ~f:(fun x -> String.ends_with ) in
+  > let n = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:47 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "String.ends_with : suffix:string -> string -> bool",
+          "parameters": [
+            {
+              "label": [
+                19,
+                32
+              ]
+            },
+            {
+              "label": [
+                36,
+                42
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is between 'map' and 'in' and triggers correctly the 'map' even if the unfinished 'iter'
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map  in
+  > let s = List.iter
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "List.map : ('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+FIXME: The cursor is after 'map' and should trigger the 'map'
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter
+  > let n = 5 in
+  > 7
+  > EOF
+
+  $ $MERLIN single signature-help -position 2:17 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+FIXME: The cursor is after the '()' of the 'iter' function. It should trigger the 'iter' with active parameter set to 1.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter () 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+FIXME: The cursor is after the 'iter' and should trigger the 'iter'.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter 
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:18 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is between the '()' and 'in' and triggers correctly the 'iter' signature help.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.map 
+  > let s = List.iter ()  in
+  > let n = 5 in
+  > EOF
+
+  $ $MERLIN single signature-help -position 3:21 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "List.iter : ('a -> unit) -> 'a list -> unit",
+          "parameters": [
+            {
+              "label": [
+                12,
+                24
+              ]
+            },
+            {
+              "label": [
+                28,
+                35
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after the 'in' of the 'let n = 5 in' and triggers nothing.
+  $ cat > test2.ml <<'EOF'
+  > let g =
+  > let f = List.hd in
+  > let s = List.iter  in
+  > let n = 5 in
+  > 9
+  > EOF
+
+  $ $MERLIN single signature-help -position 4:18 -filename test2 < test2.ml
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }

--- a/tests/test-dirs/signature-help/issue_opt_arg.t
+++ b/tests/test-dirs/signature-help/issue_opt_arg.t
@@ -1,0 +1,256 @@
+FIXME: Active parameter should be 1 because x is already written
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ~ 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> ?y:'_weak1 -> x:int -> '_weak2 -> int * '_weak1 option * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                30
+              ]
+            },
+            {
+              "label": [
+                34,
+                41
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 2,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after the `?`. There is only one optional parameter so the active parameter is y.
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ? 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> ?y:'_weak1 -> x:int -> '_weak2 -> int * '_weak1 option * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                21
+              ]
+            },
+            {
+              "label": [
+                25,
+                30
+              ]
+            },
+            {
+              "label": [
+                34,
+                41
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+This test is valid because `~y` is a complete parameter.
+  $ $MERLIN single signature-help -position 2:18 << EOF
+  > let f a ?y ~x t = (a, y, x, t)
+  > let _ = f ~x:43 ~y 1
+  > EOF
+  {
+    "class": "return",
+    "value": {},
+    "notifications": []
+  }
+
+The cursor is at the end of the second line. The function is waiting for a last labelled argument and it is `y`.
+  $ $MERLIN single signature-help -position 2:20 << EOF
+  > let f a ~x ~y t = (a, y, x, t)
+  > let _ = f 1 ~x:43 1 
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> x:int -> y:'_weak1 -> int -> int * '_weak1 * int * int",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                16
+              ]
+            },
+            {
+              "label": [
+                20,
+                29
+              ]
+            },
+            {
+              "label": [
+                33,
+                36
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 2,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+FIXME: Active parameter should be 2
+  $ $MERLIN single signature-help -position 2:17 << EOF
+  > let f a ~x ~y t = (a, y, x, t)
+  > let _ = f ~x:43 ~ 1
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "f : int -> x:int -> y:'_weak1 -> '_weak2 -> int * '_weak1 * int * '_weak2",
+          "parameters": [
+            {
+              "label": [
+                4,
+                7
+              ]
+            },
+            {
+              "label": [
+                11,
+                16
+              ]
+            },
+            {
+              "label": [
+                20,
+                29
+              ]
+            },
+            {
+              "label": [
+                33,
+                40
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after `~`. As `f` is already given in the expression, signature help waits for the next parameter as `~f` is a valid parameter.
+  $ $MERLIN single signature-help -position 2:13 <<EOF
+  > let map = ListLabels.map
+  > let _ = map ~f:Int.abs
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "map : f:(int -> int) -> int list -> int list",
+          "parameters": [
+            {
+              "label": [
+                6,
+                20
+              ]
+            },
+            {
+              "label": [
+                24,
+                32
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 1,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }
+
+The cursor is after `~`. As `f` isn't already given in the expression, signature help waits for the value of `~f`.
+  $ $MERLIN single signature-help -position 2:13 <<EOF
+  > let map = ListLabels.map
+  > let _ = map ~
+  > EOF
+  {
+    "class": "return",
+    "value": {
+      "signatures": [
+        {
+          "label": "map : f:('a -> 'b) -> 'a list -> 'b list",
+          "parameters": [
+            {
+              "label": [
+                6,
+                18
+              ]
+            },
+            {
+              "label": [
+                22,
+                29
+              ]
+            }
+          ]
+        }
+      ],
+      "activeParameter": 0,
+      "activeSignature": 0
+    },
+    "notifications": []
+  }

--- a/tests/test-dirs/signature-help/issue_opt_arg.t
+++ b/tests/test-dirs/signature-help/issue_opt_arg.t
@@ -1,4 +1,4 @@
-FIXME: Active parameter should be 1 because x is already written
+The cursor is after the second `~`. As `~x` has already been written, the active parameter is `y`.
   $ $MERLIN single signature-help -position 2:17 << EOF
   > let f a ?y ~x t = (a, y, x, t)
   > let _ = f ~x:43 ~ 1
@@ -37,7 +37,7 @@ FIXME: Active parameter should be 1 because x is already written
           ]
         }
       ],
-      "activeParameter": 2,
+      "activeParameter": 1,
       "activeSignature": 0
     },
     "notifications": []
@@ -144,7 +144,7 @@ The cursor is at the end of the second line. The function is waiting for a last 
     "notifications": []
   }
 
-FIXME: Active parameter should be 2
+The cursor is after the second `~`. As `~x` has already been written, the active parameter is `y`.
   $ $MERLIN single signature-help -position 2:17 << EOF
   > let f a ~x ~y t = (a, y, x, t)
   > let _ = f ~x:43 ~ 1
@@ -183,7 +183,7 @@ FIXME: Active parameter should be 2
           ]
         }
       ],
-      "activeParameter": 1,
+      "activeParameter": 2,
       "activeSignature": 0
     },
     "notifications": []

--- a/tests/test-dirs/signature-help/signature-help.t
+++ b/tests/test-dirs/signature-help/signature-help.t
@@ -127,8 +127,9 @@ It can make the non-labelled parameter active.
     "notifications": []
   }
 
-It can make the labelled parameter active.
-  $ $MERLIN single signature-help -position 2:14 <<EOF
+The cursor is after `:`. As `~f:` isn't a valid parameter, signature help waits for the value of `~f`.
+FIXME we could expect signature help to show the correct parameter with the cursor before the : too
+  $ $MERLIN single signature-help -position 2:15 <<EOF
   > let map = ListLabels.map
   > let _ = map ~f:Int.abs
   > EOF


### PR DESCRIPTION
Signature-help does not trigger on unfinished `let … in` bindings.
Nothing shows up if the `in` keyword is missing, and it works as expected if it is present.
This PR fixes this wrong behaviour and downstreams the work from https://github.com/ocaml/merlin/pull/2036/commits.