### PR TITLE
Upgrade to 5.4

### DIFF
--- a/.github/workflows/flambda-backend.yml
+++ b/.github/workflows/flambda-backend.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         opam depext conf-jq --yes # opam depext bug
         opam pin menhirLib 20231231 --no-action
-        opam install --yes ppx_string ppx_compare ocamlformat.0.28.1
+        opam install --yes ppx_string ppx_compare ocamlformat.0.29.0
         opam install . --deps-only --with-test --yes
 
     - name: Check formatting

--- a/.github/workflows/flambda-backend.yml
+++ b/.github/workflows/flambda-backend.yml
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-latest
             flambda-backend-config: --enable-middle-end=flambda2 --disable-naked-pointers
             name: flambda2
-            ocaml-compiler: 5.2.x
+            ocaml-compiler: 5.4.0
 
     env:
       MERLIN_TESTS: all
@@ -93,7 +93,7 @@ jobs:
       run: |
         opam depext conf-jq --yes # opam depext bug
         opam pin menhirLib 20231231 --no-action
-        opam install --yes ppx_string ppx_compare ocamlformat.0.26.2
+        opam install --yes ppx_string ppx_compare ocamlformat.0.28.1
         opam install . --deps-only --with-test --yes
 
     - name: Check formatting

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.28.1
+version=0.29.0
 disable=false
 
 break-cases=fit-or-vertical

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.26.2
+version=0.28.1
 disable=false
 
 break-cases=fit-or-vertical

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,1 +1,1 @@
-FROM ocaml/opam:ubuntu-20.04-ocaml-5.2
+FROM ocaml/opam:ubuntu-20.04-ocaml-5.4

--- a/bench.Dockerfile.disabled
+++ b/bench.Dockerfile.disabled
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-20.04-ocaml-5.2
+FROM ocaml/opam:ubuntu-20.04-ocaml-5.4
 
 WORKDIR /app
 

--- a/dot-merlin-reader.opam
+++ b/dot-merlin-reader.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.2" }
+  "ocaml" {>= "5.4" }
   "dune" {>= "2.9.0"}
   "merlin-lib" {>= "5.0"}
   "ocamlfind" {>= "1.6.0"}

--- a/merlin-lib.opam
+++ b/merlin-lib.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.2" & < "5.3"}
+  "ocaml" {>= "5.4" & < "5.5"}
   "dune" {>= "3.0.0"}
   "csexp" {>= "1.5.1"}
   "alcotest" {with-test}

--- a/merlin.opam
+++ b/merlin.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "5.2" & < "5.3"}
+  "ocaml" {>= "5.4" & < "5.5"}
   "dune" {>= "3.0.0"}
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "5.0"}
@@ -22,7 +22,6 @@ depends: [
 ]
 conflicts: [
   "seq" {!= "base"}
-  "base-effects"
 ]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"

--- a/ocaml-index.opam
+++ b/ocaml-index.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml/merlin/ocaml-index"
 bug-reports: "https://github.com/ocaml/merlin/issues"
 depends: [
   "dune" {>= "3.0.0"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.4"}
   "merlin-lib" {>= "5.1-502"}
   "odoc" {with-doc}
 ]

--- a/src/analysis/ast_iterators.ml
+++ b/src/analysis/ast_iterators.ml
@@ -147,20 +147,18 @@ let build_uid_to_locs_tbl ~(local_defs : Mtyper.typedtree) () =
     Types.Uid.Tbl.create 64
   in
   let iter = iter_on_defs ~uid_to_locs_tbl in
-  begin
-    match local_defs with
-    | `Interface sign -> iter.signature iter sign
-    | `Implementation str -> iter.structure iter str
+  begin match local_defs with
+  | `Interface sign -> iter.signature iter sign
+  | `Implementation str -> iter.structure iter str
   end;
   uid_to_locs_tbl
 
 let iter_on_usages ~f (local_defs : Mtyper.typedtree) =
   let occ_iter = Cmt_format.iter_on_occurrences ~f in
   let iter = iter_only_visible occ_iter in
-  begin
-    match local_defs with
-    | `Interface signature -> iter.signature iter signature
-    | `Implementation structure -> iter.structure iter structure
+  begin match local_defs with
+  | `Interface signature -> iter.signature iter signature
+  | `Implementation structure -> iter.structure iter structure
   end
 
 let iterator_on_usages ~include_hidden ~f =

--- a/src/analysis/browse_misc.ml
+++ b/src/analysis/browse_misc.ml
@@ -77,12 +77,12 @@ let signature_of_env ?(ignore_extensions = true) env =
     (* Trec_not == bluff, FIXME *)
     | Env_type (_, i, t) -> Some (Sig_type (i, t, Trec_not, Exported))
     (* Texp_first == bluff, FIXME *)
-    | Env_extension (_, i, e) -> begin
-      match e.ext_type_path with
+    | Env_extension (_, i, e) ->
+      begin match e.ext_type_path with
       | Path.Pident id when Ident.name id = "exn" ->
         Some (Sig_typext (i, e, Text_exception, Exported))
       | _ -> Some (Sig_typext (i, e, Text_first, Exported))
-    end
+      end
     | Env_module (_, i, pr, m, _, _) ->
       Some (Sig_module (i, pr, m, Trec_not, Exported))
     | Env_modtype (_, i, m) -> Some (Sig_modtype (i, m, Exported))

--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -60,12 +60,12 @@ let raw_info_printer : raw_info -> _ = function
       (Out_sig_item
          (Printtyp.tree_of_type_declaration id tdecl Types.Trec_first))
   | `Type_scheme te -> `Print (Out_type (Printtyp.tree_of_type_scheme te))
-  | `Variant (label, arg) -> begin
-    match arg with
+  | `Variant (label, arg) ->
+    begin match arg with
     | None -> `String label
     | Some te ->
       `Concat (label ^ " of ", Out_type (Printtyp.tree_of_type_scheme te))
-  end
+    end
 
 (* List methods of an object.
    Code taken from [uTop](https://github.com/diml/utop
@@ -80,12 +80,12 @@ let rec methods_of_type env ?(acc = []) type_expr =
     methods_of_type env ~acc type_expr
   | Tfield (name, _, ty, rest) ->
     methods_of_type env ~acc:((name, ty) :: acc) rest
-  | Tconstr (path, _, _) -> begin
-    match lookup_env Env.find_type path env with
+  | Tconstr (path, _, _) ->
+    begin match lookup_env Env.find_type path env with
     | None | Some { type_manifest = None; _ } -> acc
     | Some { type_manifest = Some type_expr; _ } ->
       methods_of_type env ~acc type_expr
-  end
+    end
   | _ -> acc
 
 let classify_node = function
@@ -189,8 +189,8 @@ let make_candidate ~get_doc ~attrs ~exact ~prefix_path name ?loc ?path ty =
               commu_ok ))
       in
       (`Label, `Type_scheme (Btype.newgenty desc))
-    | `Mod m -> begin
-      try
+    | `Mod m ->
+      begin try
         if not exact then raise Exit;
         let verbosity =
           Mconfig.Verbosity.to_int !Type_utils.verbosity ~for_smart:1
@@ -199,7 +199,7 @@ let make_candidate ~get_doc ~attrs ~exact ~prefix_path name ?loc ?path ty =
           raise Exit;
         (`Module, `Modtype m)
       with Exit -> (`Module, `None)
-    end
+      end
     | `ModType m ->
       if exact then
         (`Modtype, `Modtype_declaration (ident, (*verbose_sig env*) m))
@@ -238,11 +238,10 @@ let make_candidate ~get_doc ~attrs ~exact ~prefix_path name ?loc ?path ty =
           | `Type -> Type
           | _ -> assert false
         in
-        begin
-          match get_doc (`Completion_entry (namespace, p, loc)) with
-          | `Found str -> `String str
-          | _ -> `None
-          | exception _ -> `None
+        begin match get_doc (`Completion_entry (namespace, p, loc)) with
+        | `Found str -> `String str
+        | _ -> `None
+        | exception _ -> `None
         end
       | _, _ -> `None)
   in
@@ -301,14 +300,13 @@ let fold_sumtype_constructors ~env ~init ~f t =
   match t.desc with
   | Tconstr (path, _, _) ->
     log ~title:"fold_sumtype_constructors" "node type: %s" (Path.name path);
-    begin
-      match Env.find_type_descrs path env with
-      | exception Not_found -> init
-      | Type_record _
-      | Type_record_unboxed_product _
-      | Type_abstract _
-      | Type_open -> init
-      | Type_variant (constrs, _, _) -> List.fold_right constrs ~init ~f
+    begin match Env.find_type_descrs path env with
+    | exception Not_found -> init
+    | Type_record _
+    | Type_record_unboxed_product _
+    | Type_abstract _
+    | Type_open -> init
+    | Type_variant (constrs, _, _) -> List.fold_right constrs ~init ~f
     end
   | _ -> init
 
@@ -444,12 +442,11 @@ let get_candidates ?get_doc ?target_type ?prefix_path ~prefix kind ~validate env
         let in_scope_candidates =
           Env.fold_constructors consider_constr prefix_path env []
         in
-        begin
-          match (prefix_path, target_type) with
-          | Some _, _ | _, None -> in_scope_candidates
-          | None, Some ty ->
-            fold_sumtype_constructors ~env ~init:in_scope_candidates
-              ~f:consider_constr ty
+        begin match (prefix_path, target_type) with
+        | Some _, _ | _, None -> in_scope_candidates
+        | None, Some ty ->
+          fold_sumtype_constructors ~env ~init:in_scope_candidates
+            ~f:consider_constr ty
         end
       | `Types ->
         Env.fold_types
@@ -542,7 +539,10 @@ let complete_methods ~env ~prefix obj =
   in
   let methods = List.filter ~f:has_prefix (methods_of_type env t) in
   List.map methods ~f:(fun (name, ty) ->
-      let info = `None (* TODO: get documentation. *) in
+      let info =
+        `None
+        (* TODO: get documentation. *)
+      in
       { name;
         kind = `MethodCall;
         desc = `Type_scheme ty;
@@ -713,8 +713,8 @@ let branch_complete buffer ?get_doc ?target_type ?kinds ~keywords prefix :
       let snap = Btype.snapshot () in
       let is_label =
         match lbl.Types.lbl_all with
-        | [||] -> begin
-          match
+        | [||] ->
+          begin match
             let ty =
               match parent with
               | `Expression e -> e.Typedtree.exp_type
@@ -723,8 +723,8 @@ let branch_complete buffer ?get_doc ?target_type ?kinds ~keywords prefix :
             let decl = Ctype.extract_concrete_typedecl env ty in
             (ty, decl)
           with
-          | ty, Typedecl (p, _, decl) -> begin
-            try
+          | ty, Typedecl (p, _, decl) ->
+            begin try
               let lbls = Datarepr.labels_of_type p decl in
               let labels =
                 List.map lbls ~f:(fun (_, lbl) ->
@@ -732,8 +732,7 @@ let branch_complete buffer ?get_doc ?target_type ?kinds ~keywords prefix :
                       let _, lbl_arg, lbl_res =
                         Ctype.instance_label ~fixed:false lbl
                       in
-                      begin
-                        try Ctype.unify_var env ty lbl_res with _ -> ()
+                      begin try Ctype.unify_var env ty lbl_res with _ -> ()
                       end;
                       (* FIXME: the two subst can lose some sharing between types *)
                       let lbl_res = Subst.type_expr Subst.identity lbl_res in
@@ -746,9 +745,9 @@ let branch_complete buffer ?get_doc ?target_type ?kinds ~keywords prefix :
               match decl.Types.type_kind with
               | Types.Type_record (lbls, _, _) -> Declaration (ty, lbls)
               | _ -> Maybe)
-          end
+            end
           | _ | (exception _) -> Maybe
-        end
+          end
         | lbls -> Description (Array.to_list lbls)
       in
       let result =

--- a/src/analysis/construct.ml
+++ b/src/analysis/construct.ml
@@ -122,12 +122,12 @@ module Util = struct
               See c-simple, test 6.2b for an example *)
           Btype.backtrack snap;
           Some params
-        | None -> begin
-          match type_expr.desc with
+        | None ->
+          begin match type_expr.desc with
           | Tarrow ((arg_label, _, _), _, te, _) ->
             check_type te (arg_label :: params)
           | _ -> None
-        end
+          end
       in
       (* TODO we should probably sort the results better *)
       match (is_in_stdlib path, check_type value_description.val_type []) with
@@ -362,17 +362,17 @@ module Gen = struct
           (make_param (Labelled s) (Pat.var (Location.mknoloc s)), s)
         | Optional s ->
           (make_param (Optional s) (Pat.var (Location.mknoloc s)), s)
-        | Nolabel -> begin
-          match get_desc ty with
-          | Tpoly (poly, []) -> begin
-            match get_desc poly with
+        | Nolabel ->
+          begin match get_desc ty with
+          | Tpoly (poly, []) ->
+            begin match get_desc poly with
             | Tconstr (path, _, _) ->
               let name = uniq_name env (Path.last path) in
               (make_param Nolabel (Pat.var (Location.mknoloc name)), name)
             | _ -> (make_param Nolabel (Pat.any ()), "_")
-          end
+            end
           | _ -> (make_param Nolabel (Pat.any ()), "_")
-        end
+          end
     in
 
     let constructor env type_expr path constrs =
@@ -446,9 +446,9 @@ module Gen = struct
       | row_descrs ->
         List.map row_descrs ~f:(fun (lbl, row_field) ->
             (match row_field_repr row_field with
-            | Reither (false, [ ty ], _) | Rpresent (Some ty) ->
-              List.map ~f:(fun s -> Some s) (exp_or_hole env ty)
-            | _ -> [ None ])
+              | Reither (false, [ ty ], _) | Rpresent (Some ty) ->
+                List.map ~f:(fun s -> Some s) (exp_or_hole env ty)
+              | _ -> [ None ])
             |> List.map ~f:(fun e -> Ast_helper.Exp.variant lbl e))
         |> List.flatten |> List.rev
     in
@@ -475,10 +475,10 @@ module Gen = struct
       let lbl_lids, lbl_exprs = List.split labels in
       Util.combinations lbl_exprs
       |> List.map ~f:(fun lbl_exprs ->
-             let labels =
-               List.map2 lbl_lids lbl_exprs ~f:(fun lid exp -> (lid, exp))
-             in
-             Ast_helper.Exp.record labels None)
+          let labels =
+            List.map2 lbl_lids lbl_exprs ~f:(fun lid exp -> (lid, exp))
+          in
+          Ast_helper.Exp.record labels None)
     in
 
     (* Given a typed hole, there is two possible forms of constructions:
@@ -499,8 +499,8 @@ module Gen = struct
           (* Special case for lazy *)
           let exps = exp_or_hole env texp in
           List.map exps ~f:Ast_helper.Exp.lazy_
-        | Tconstr (path, _params, _) -> begin
-          try
+        | Tconstr (path, _params, _) ->
+          begin try
             (* If this is a "basic" type we propose a default value *)
             [ Hashtbl.find Util.predef_types path ]
           with Not_found -> (
@@ -511,7 +511,7 @@ module Gen = struct
             | Type_record_unboxed_product (labels, _, _) ->
               record env rtyp path labels Unboxed_product
             | Type_abstract _ | Type_open -> [])
-        end
+          end
         | Tarrow _ ->
           let rec left_types acc env ty =
             match get_desc ty with
@@ -584,7 +584,7 @@ module Gen = struct
           with Typemod.Error _ ->
             let name = Ident.name (Path.head path) in
             raise (Modtype_not_found (Modtype, name))
-        end
+          end
         | Tobject (fields, _) ->
           let rec aux acc fields =
             match get_desc fields with
@@ -595,9 +595,9 @@ module Gen = struct
               let exprs =
                 exp_or_hole env type_expr
                 |> List.map ~f:(fun expr ->
-                       let open Ast_helper in
-                       Cf.method_ (Location.mknoloc name) Asttypes.Public
-                       @@ Ast_helper.Cf.concrete Asttypes.Fresh expr)
+                    let open Ast_helper in
+                    Cf.method_ (Location.mknoloc name) Asttypes.Public
+                    @@ Ast_helper.Cf.concrete Asttypes.Fresh expr)
               in
               aux (exprs :: acc) fields
             | _ ->

--- a/src/analysis/destruct.ml
+++ b/src/analysis/destruct.ml
@@ -99,8 +99,8 @@ let rec gen_patterns ?(recurse = true) env type_expr =
       List.combine (List.map ~f:fst lst) (Patterns.omega_list lst)
     in
     [ Tast_helper.Pat.tuple env type_expr patterns ]
-  | Tconstr (path, _params, _) -> begin
-    match Env.find_type_descrs path env with
+  | Tconstr (path, _params, _) ->
+    begin match Env.find_type_descrs path env with
     | Type_record (labels, _, _) ->
       let lst =
         List.map labels ~f:(fun lbl_descr ->
@@ -163,7 +163,7 @@ let rec gen_patterns ?(recurse = true) env type_expr =
       else
         raise
           (Not_allowed (sprintf "non-destructible type: %s" (Path.last path)))
-  end
+    end
   | Tvariant row_desc ->
     List.filter_map (row_fields row_desc) ~f:(fun (lbl, row_field) ->
         match (lbl, row_field_repr row_field) with
@@ -200,18 +200,18 @@ let rec needs_parentheses = function
   | t :: ts -> (
     match t with
     | Structure _ | Structure_item _ | Value_binding _ -> false
-    | Expression e -> begin
-      match e.Typedtree.exp_desc with
+    | Expression e ->
+      begin match e.Typedtree.exp_desc with
       | Texp_for _ | Texp_while _ -> false
       | Texp_let _
       (* We are after the "in" keyword, we need to look at the parent of the
          binding. *)
       | Texp_function { body = Tfunction_body _; _ }
       (* The assumption here is that we're not in a [function ... | ...]
-          situation but either in [fun param] or [let name param]. *) ->
-        needs_parentheses ts
+          situation but either in [fun param] or [let name param]. *)
+        -> needs_parentheses ts
       | _ -> true
-    end
+      end
     | _ -> needs_parentheses ts)
 
 let rec get_match = function
@@ -276,15 +276,15 @@ let collect_every_pattern_for_expression parent =
                 in
                 if Typedtree.exists_general_pattern ill_typed_pred p then
                   raise Ill_typed
-                else begin
-                  match Typedtree.classify_pattern p with
+                else
+                  begin match Typedtree.classify_pattern p with
                   | Value -> (p : Typedtree.pattern) :: acc
-                  | Computation -> begin
-                    match Typedtree.split_pattern p with
+                  | Computation ->
+                    begin match Typedtree.split_pattern p with
                     | Some p, _ -> (p : Typedtree.pattern) :: acc
                     | None, _ -> acc
+                    end
                   end
-                end
               | _ -> acc)
             env node acc
         | _ -> acc)
@@ -316,10 +316,9 @@ let rec get_every_pattern loc = function
         { exp_desc = Typedtree.Texp_ident { path = Path.Pident id; _ }; _ }
       when Ident.name id = "*type-error*" -> raise Ill_typed
     | Expression { exp_desc = Typedtree.Texp_function { params; _ }; _ } ->
-    begin
       (* So we need to deal with the case where we're either in the body of a
          function, or in a function parameter. *)
-      match
+      begin match
         List.find_some
           ~f:(fun param ->
             Location_aux.included ~into:param.Typedtree.fp_loc loc)
@@ -331,7 +330,7 @@ let rec get_every_pattern loc = function
       | None ->
         (* In function body *)
         collect_every_pattern_for_expression parent
-    end
+      end
     | Expression _ ->
       (* We are on the right node *)
       collect_every_pattern_for_expression parent
@@ -514,17 +513,16 @@ let rec qualify_constructors ~unmangling_tables f pat =
             | Some cstr_des -> cstr_des.Types.cstr_name
             | None -> name
           in
-          begin
-            match Types.get_desc pat.pat_type with
-            | Types.Tconstr (path, _, _) ->
-              let path = f pat.pat_env path in
-              let env_check = Env.find_constructor_by_name in
-              let txt =
-                Misc_utils.Path.to_shortest_lid ~env:pat.pat_env ~name
-                  ~env_check path
-              in
-              { lid with Asttypes.txt }
-            | _ -> lid
+          begin match Types.get_desc pat.pat_type with
+          | Types.Tconstr (path, _, _) ->
+            let path = f pat.pat_env path in
+            let env_check = Env.find_constructor_by_name in
+            let txt =
+              Misc_utils.Path.to_shortest_lid ~env:pat.pat_env ~name ~env_check
+                path
+            in
+            { lid with Asttypes.txt }
+          | _ -> lid
           end
         | _ -> lid (* already qualified *)
       in
@@ -797,17 +795,16 @@ let refine_complete_match (type a) parents (patt : a Typedtree.general_pattern)
     if not (destructible patt) then raise Nothing_to_do
     else
       let ty = patt.Typedtree.pat_type in
-      begin
-        match gen_patterns patt.Typedtree.pat_env ty with
-        | [] -> assert false
-        | [ more_precise_pattern ] ->
-          (* If only one pattern is generated, then we're only refining the
+      begin match gen_patterns patt.Typedtree.pat_env ty with
+      | [] -> assert false
+      | [ more_precise_pattern ] ->
+        (* If only one pattern is generated, then we're only refining the
              current pattern, not generating new branches. *)
-          refine_current_pattern parents patt config source more_precise_pattern
-        | sub_patterns ->
-          (* If more than one pattern is generated, then we're generating new
+        refine_current_pattern parents patt config source more_precise_pattern
+      | sub_patterns ->
+        (* If more than one pattern is generated, then we're generating new
              branches. *)
-          refine_and_generate_branches patt config source patterns sub_patterns
+        refine_and_generate_branches patt config source patterns sub_patterns
       end
 
 let destruct_pattern (type a) (patt : a Typedtree.general_pattern) config source

--- a/src/analysis/index_occurrences.ml
+++ b/src/analysis/index_occurrences.ml
@@ -11,24 +11,24 @@ let set_fname ~file (loc : Location.t) =
 
 let decl_of_path_or_lid env namespace path lid =
   match (namespace : Shape.Sig_component_kind.t) with
-  | Constructor -> begin
-    match Env.find_constructor_by_name lid env with
+  | Constructor ->
+    begin match Env.find_constructor_by_name lid env with
     | exception Not_found -> None
     | { cstr_uid; cstr_loc; _ } ->
       Some { Env_lookup.uid = cstr_uid; loc = cstr_loc; namespace }
-  end
-  | Label -> begin
-    match Env.find_label_by_name Legacy lid env with
+    end
+  | Label ->
+    begin match Env.find_label_by_name Legacy lid env with
     | exception Not_found -> None
     | { lbl_uid; lbl_loc; _ } ->
       Some { Env_lookup.uid = lbl_uid; loc = lbl_loc; namespace }
-  end
-  | Unboxed_label -> begin
-    match Env.find_label_by_name Unboxed_product lid env with
+    end
+  | Unboxed_label ->
+    begin match Env.find_label_by_name Unboxed_product lid env with
     | exception Not_found -> None
     | { lbl_uid; lbl_loc; _ } ->
       Some { Env_lookup.uid = lbl_uid; loc = lbl_loc; namespace }
-  end
+    end
   | _ -> Env_lookup.by_path path namespace env
 
 let should_ignore_lid (lid : Longident.t Location.loc) =
@@ -51,14 +51,13 @@ let iterator ~current_buffer_path ~index ~reduce_for_uid =
       (Fun.flip (Format_doc.compat Path.print) path);
     let lid = { lid with loc = set_fname ~file:current_buffer_path lid.loc } in
     let index_decl () =
-      begin
-        match decl_of_path_or_lid env namespace path lid.txt with
-        | (exception _) | None ->
-          log ~title:"index_buffer" "Declaration not found"
-        | Some decl ->
-          log ~title:"index_buffer" "Found declaration: %a" Logger.fmt
-            (Fun.flip Location.print_loc decl.loc);
-          add decl.uid lid
+      begin match decl_of_path_or_lid env namespace path lid.txt with
+      | (exception _) | None ->
+        log ~title:"index_buffer" "Declaration not found"
+      | Some decl ->
+        log ~title:"index_buffer" "Found declaration: %a" Logger.fmt
+          (Fun.flip Location.print_loc decl.loc);
+        add decl.uid lid
       end
     in
     if not (should_ignore_lid lid) then
@@ -68,24 +67,23 @@ let iterator ~current_buffer_path ~index ~reduce_for_uid =
         log ~title:"index_buffer" "Shape of path: %a" Logger.fmt
           (Fun.flip Shape.print path_shape);
         let result = reduce_for_uid env path_shape in
-        begin
-          match Locate.uid_of_result ~traverse_aliases:false result with
-          | Some uid, false ->
-            log ~title:"index_buffer" "Found %a (%a) wiht uid %a" Logger.fmt
-              (Fun.flip Pprintast.longident lid.txt)
-              Logger.fmt
-              (Fun.flip Location.print_loc lid.loc)
-              Logger.fmt
-              (Fun.flip Shape.Uid.print uid);
-            add uid lid
-          | Some uid, true ->
-            log ~title:"index_buffer" "Shape is approximative, found uid: %a"
-              Logger.fmt
-              (Fun.flip Shape.Uid.print uid);
-            index_decl ()
-          | None, _ ->
-            log ~title:"index_buffer" "Reduction failed: missing uid";
-            index_decl ()
+        begin match Locate.uid_of_result ~traverse_aliases:false result with
+        | Some uid, false ->
+          log ~title:"index_buffer" "Found %a (%a) wiht uid %a" Logger.fmt
+            (Fun.flip Pprintast.longident lid.txt)
+            Logger.fmt
+            (Fun.flip Location.print_loc lid.loc)
+            Logger.fmt
+            (Fun.flip Shape.Uid.print uid);
+          add uid lid
+        | Some uid, true ->
+          log ~title:"index_buffer" "Shape is approximative, found uid: %a"
+            Logger.fmt
+            (Fun.flip Shape.Uid.print uid);
+          index_decl ()
+        | None, _ ->
+          log ~title:"index_buffer" "Reduction failed: missing uid";
+          index_decl ()
         end
   in
   Ast_iterators.iterator_on_usages ~include_hidden:true ~f

--- a/src/analysis/jump.ml
+++ b/src/analysis/jump.ml
@@ -225,28 +225,30 @@ let phrase typed_tree pos target =
   in
   let rec seek_item = function
     | [] -> None
-    | Browse_raw.Signature xs :: tail -> begin
-      match find_pos (fun x -> x.Typedtree.sig_loc) xs.Typedtree.sig_items with
+    | Browse_raw.Signature xs :: tail ->
+      begin match
+        find_pos (fun x -> x.Typedtree.sig_loc) xs.Typedtree.sig_items
+      with
       | [] -> seek_item tail
       | y :: _ -> Some y.Typedtree.sig_loc
-    end
-    | Browse_raw.Structure xs :: tail -> begin
-      match find_pos (fun x -> x.Typedtree.str_loc) xs.Typedtree.str_items with
+      end
+    | Browse_raw.Structure xs :: tail ->
+      begin match
+        find_pos (fun x -> x.Typedtree.str_loc) xs.Typedtree.str_items
+      with
       | [] -> seek_item tail
       | y :: _ -> Some y.Typedtree.str_loc
-    end
+      end
     | Browse_raw.Signature_item (x, _) :: Browse_raw.Signature xs :: tail ->
-    begin
-      match find_item x xs.Typedtree.sig_items with
+      begin match find_item x xs.Typedtree.sig_items with
       | [] -> seek_item tail
       | y :: _ -> Some y.Typedtree.sig_loc
-    end
+      end
     | Browse_raw.Structure_item (x, _) :: Browse_raw.Structure xs :: tail ->
-    begin
-      match find_item x xs.Typedtree.str_items with
+      begin match find_item x xs.Typedtree.str_items with
       | [] -> seek_item tail
       | y :: _ -> Some y.Typedtree.str_loc
-    end
+      end
     | _ :: xs -> seek_item xs
   in
   match (seek_item enclosing, target) with

--- a/src/analysis/locate.ml
+++ b/src/analysis/locate.ml
@@ -282,10 +282,9 @@ end = struct
     | None -> `No_documentation
     | Some attr ->
       log ~title:"doc_from_uid" "Found attributes for this uid";
-      begin
-        match find_doc_attribute [ attr ] with
-        | Some (doc, _) -> `Found_doc (doc |> String.trim)
-        | None -> `No_documentation
+      begin match find_doc_attribute [ attr ] with
+      | Some (doc, _) -> `Found_doc (doc |> String.trim)
+      | None -> `No_documentation
       end
 
   let doc_of_item_declaration decl =
@@ -317,8 +316,8 @@ end = struct
         match find_doc_attribute attributes with
         | Some (doc, _) -> `Found_doc (doc |> String.trim)
         | None -> `No_documentation))
-    | Cmt cmt_infos -> begin
-      match uid with
+    | Cmt cmt_infos ->
+      begin match uid with
       | Shape.Uid.Compilation_unit _ ->
         (* For module doc we need to look at the first items in the typedtree *)
         find_compunit_doc_in_typedtree cmt_infos
@@ -328,13 +327,13 @@ end = struct
         in
         match decl with
         | None -> `No_documentation
-        | Some decl -> begin
-          match doc_of_item_declaration decl with
+        | Some decl ->
+          begin match doc_of_item_declaration decl with
           | `Found_doc d -> `Found_doc d
           | `No_documentation -> `Found_decl (uid, decl, cmt_infos.cmt_comments)
+          end
         end
       end
-    end
 
   let read file =
     match File.of_filename file with
@@ -576,11 +575,11 @@ let scrape_alias ~env ~fallback_uid ~namespace path =
     | Shape.Sig_component_kind.Module ->
       let { Types.md_type; md_uid; _ } = Env.find_module path env in
       (md_type, md_uid)
-    | Module_type -> begin
-      match Env.find_modtype path env with
+    | Module_type ->
+      begin match Env.find_modtype path env with
       | { Types.mtd_type = Some mtd_type; mtd_uid; _ } -> (mtd_type, mtd_uid)
       | _ -> raise Not_found
-    end
+      end
     | _ -> raise Not_found
   in
   let rec non_alias_declaration_uid ~fallback_uid path =
@@ -637,12 +636,13 @@ let find_source ~config loc =
     log ~title:"find_source" "failed to find %S in source path (fallback = %b)"
       filename with_fallback;
     log ~title:"find_source" "looking for %S in %S" (File.name file) dir;
-    begin
-      match Utils.find_file_with_path ~config ~with_fallback file [ dir ] with
-      | Some source -> Found source
-      | None -> (
-        log ~title:"find_source" "Trying to find %S in %S directly" fname dir;
-        try Found (Misc.find_in_path [ dir ] fname) with _ -> Not_found file)
+    begin match
+      Utils.find_file_with_path ~config ~with_fallback file [ dir ]
+    with
+    | Some source -> Found source
+    | None -> (
+      log ~title:"find_source" "Trying to find %S in %S directly" fname dir;
+      try Found (Misc.find_in_path [ dir ] fname) with _ -> Not_found file)
     end
   | [ x ] -> Found x
   | files -> (
@@ -1121,28 +1121,27 @@ let from_string ~config ~env ~local_defs ~pos ?let_pun_behavior
   Option.value_map ~f:from_lid ~default:(`Not_found (path, None)) lid
 
 let doc_from_uid ~config ~loc uid =
-  begin
-    match uid with
-    | (Shape.Uid.Item { comp_unit; _ } | Shape.Uid.Compilation_unit comp_unit)
-      when not (Misc_utils.is_current_unit comp_unit) ->
-      log ~title:"get_doc"
-        "the doc (%a) you're looking for is in another\n\
-        \      compilation unit (%s)" Logger.fmt
-        (fun fmt -> Shape.Uid.print fmt uid)
-        comp_unit;
-      log ~title:"doc_from_uid" "Loading the cmt for unit %S" comp_unit;
-      begin
-        match load_cmt ~config:{ config with ml_or_mli = `MLI } comp_unit with
-        | Error _ -> `No_documentation
-        | Ok (_, artifact) ->
-          log ~title:"doc_from_uid" "Cmt loaded for %s"
-            (Option.value ~default:"<>" (Artifact.sourcefile artifact));
-          Artifact.uid_to_docstring uid artifact
-      end
-    | _ ->
-      (* Uid based search doesn't works in the current CU since Merlin's parser
+  begin match uid with
+  | (Shape.Uid.Item { comp_unit; _ } | Shape.Uid.Compilation_unit comp_unit)
+    when not (Misc_utils.is_current_unit comp_unit) ->
+    log ~title:"get_doc"
+      "the doc (%a) you're looking for is in another\n\
+      \      compilation unit (%s)"
+      Logger.fmt
+      (fun fmt -> Shape.Uid.print fmt uid)
+      comp_unit;
+    log ~title:"doc_from_uid" "Loading the cmt for unit %S" comp_unit;
+    begin match load_cmt ~config:{ config with ml_or_mli = `MLI } comp_unit with
+    | Error _ -> `No_documentation
+    | Ok (_, artifact) ->
+      log ~title:"doc_from_uid" "Cmt loaded for %s"
+        (Option.value ~default:"<>" (Artifact.sourcefile artifact));
+      Artifact.uid_to_docstring uid artifact
+    end
+  | _ ->
+    (* Uid based search doesn't works in the current CU since Merlin's parser
          does not attach doc comments to the typedtree *)
-      `Found_loc loc
+    `Found_loc loc
   end
 
 let doc_from_comment_list ~after_only ~buffer_comments loc =
@@ -1189,27 +1188,23 @@ let get_doc ~config:mconfig ~env ~local_defs ~comments ~pos =
           Logger.fmt (fun fmt -> (Format_doc.compat Path.print) fmt path);
 
         let from_path = from_path ~config ~env ~local_defs ~namespace path in
-        begin
-          match from_path with
-          | `Found { uid; location = loc; _ }
-          | `File_not_found { uid; location = loc; _ } ->
-            doc_from_uid ~config ~loc uid
-          | (`Builtin _ | `Not_in_env _ | `Not_found _) as otherwise ->
-            otherwise
+        begin match from_path with
+        | `Found { uid; location = loc; _ }
+        | `File_not_found { uid; location = loc; _ } ->
+          doc_from_uid ~config ~loc uid
+        | (`Builtin _ | `Not_in_env _ | `Not_found _) as otherwise -> otherwise
         end
       | `User_input path ->
         log ~title:"get_doc" "looking for the doc of '%s'" path;
-        begin
-          match from_string ~config ~env ~local_defs ~pos path with
-          | `Found { uid; location = loc; _ }
-          | `File_not_found { uid; location = loc; _ } ->
-            doc_from_uid ~config ~loc uid
-          | `At_origin ->
-            `Found_loc
-              { Location.loc_start = pos; loc_end = pos; loc_ghost = true }
-          | `Missing_labels_namespace -> `No_documentation
-          | (`Builtin _ | `Not_in_env _ | `Not_found _) as otherwise ->
-            otherwise
+        begin match from_string ~config ~env ~local_defs ~pos path with
+        | `Found { uid; location = loc; _ }
+        | `File_not_found { uid; location = loc; _ } ->
+          doc_from_uid ~config ~loc uid
+        | `At_origin ->
+          `Found_loc
+            { Location.loc_start = pos; loc_end = pos; loc_ghost = true }
+        | `Missing_labels_namespace -> `No_documentation
+        | (`Builtin _ | `Not_in_env _ | `Not_found _) as otherwise -> otherwise
         end
     in
     match doc_from_uid_result with
@@ -1231,19 +1226,18 @@ let get_doc ~config:mconfig ~env ~local_defs ~comments ~pos =
         Mbrowse.(leaf_node @@ deepest_before loc.Location.loc_start [ browse ])
       in
       let after_only =
-        begin
-          match deepest_before with
-          | Browse_raw.Constructor_declaration _ -> true
-          (* The remaining `true` cases are currently not reachable *)
-          | Label_declaration _ | Record_field _ | Row_field _ -> true
-          | _ -> false
+        begin match deepest_before with
+        | Browse_raw.Constructor_declaration _ -> true
+        (* The remaining `true` cases are currently not reachable *)
+        | Label_declaration _ | Record_field _ | Row_field _ -> true
+        | _ -> false
         end
       in
       doc_from_comment_list ~after_only ~buffer_comments:comments loc
-    | `Builtin _ -> begin
-      match path with
+    | `Builtin _ ->
+      begin match path with
       | `User_input path -> `Builtin path
       | `Completion_entry (_, path, _) -> `Builtin (Path.name path)
-    end
+      end
     | (`Not_found _ | `No_documentation | `Not_in_env _) as otherwise ->
       otherwise

--- a/src/analysis/misc_utils.ml
+++ b/src/analysis/misc_utils.ml
@@ -73,17 +73,15 @@ let reconstruct_identifier pipeline pos = function
       then dot
       else "( " ^ dot ^ ")"
     in
-    begin
-      match path with
-      | [] -> []
-      | base :: tail ->
-        let f { Location.txt = base; loc = bl } { Location.txt = dot; loc = dl }
-            =
-          let loc = Location_aux.union bl dl in
-          let txt = base ^ "." ^ reify dot in
-          Location.mkloc txt loc
-        in
-        [ List.fold_left tail ~init:base ~f ]
+    begin match path with
+    | [] -> []
+    | base :: tail ->
+      let f { Location.txt = base; loc = bl } { Location.txt = dot; loc = dl } =
+        let loc = Location_aux.union bl dl in
+        let txt = base ^ "." ^ reify dot in
+        Location.mkloc txt loc
+      in
+      [ List.fold_left tail ~init:base ~f ]
     end
   | Some (expr, offset) ->
     let loc_start =

--- a/src/analysis/occurrences.ml
+++ b/src/analysis/occurrences.ml
@@ -265,7 +265,7 @@ let lookup_related_uids_in_indexes ~(config : Mconfig.t) uid =
   in
   Uid_map.find_opt uid related_uids
   |> Option.value_map ~default:[] ~f:(fun x ->
-         x |> Union_find.get |> Uid_set.to_list)
+      x |> Union_find.get |> Uid_set.to_list)
 
 let find_linked_uids ~config ~scope ~name uid =
   let title = "find_linked_uids" in
@@ -398,13 +398,13 @@ let locs_of ~config ~env ~typer_result ~pos ~scope path =
                   | Some path ->
                     let file = Filename.concat path loc.loc_start.pos_fname in
                     Some (set_fname ~file loc)
-                  | None -> begin
-                    match Locate.find_source ~config loc fname with
+                  | None ->
+                    begin match Locate.find_source ~config loc fname with
                     | `Found (file, _) -> Some (set_fname ~file loc)
                     | `File_not_found msg ->
                       log ~title:"occurrences" "%s" msg;
                       None
-                  end
+                    end
               in
               Option.map loc ~f:(fun loc : Query_protocol.occurrence ->
                   { loc; is_stale = Staleness.is_stale staleness })))

--- a/src/analysis/outline.ml
+++ b/src/analysis/outline.ml
@@ -68,14 +68,13 @@ let rec summarize ~include_types node =
   match node.t_node with
   | Value_binding vb ->
     let deprecated = Type_utils.is_deprecated vb.vb_attributes in
-    begin
-      match id_of_patt vb.vb_pat with
-      | None -> None
-      | Some ident ->
-        let typ =
-          outline_type ~include_types ~env:node.t_env vb.vb_pat.pat_type
-        in
-        Some (mk ~location ~deprecated `Value typ ident)
+    begin match id_of_patt vb.vb_pat with
+    | None -> None
+    | Some ident ->
+      let typ =
+        outline_type ~include_types ~env:node.t_env vb.vb_pat.pat_type
+      in
+      Some (mk ~location ~deprecated `Value typ ident)
     end
   | Value_description vd ->
     let deprecated = Type_utils.is_deprecated vd.val_attributes in
@@ -83,21 +82,19 @@ let rec summarize ~include_types node =
     Some (mk ~location ~deprecated `Value typ vd.val_id)
   | Module_declaration md ->
     let children = get_mod_children ~include_types node in
-    begin
-      match md.md_id with
-      | None -> None
-      | Some id ->
-        let deprecated = Type_utils.is_deprecated md.md_attributes in
-        Some (mk ~children ~location ~deprecated `Module None id)
+    begin match md.md_id with
+    | None -> None
+    | Some id ->
+      let deprecated = Type_utils.is_deprecated md.md_attributes in
+      Some (mk ~children ~location ~deprecated `Module None id)
     end
   | Module_binding mb ->
     let children = get_mod_children ~include_types node in
-    begin
-      match mb.mb_id with
-      | None -> None
-      | Some id ->
-        let deprecated = Type_utils.is_deprecated mb.mb_attributes in
-        Some (mk ~children ~location ~deprecated `Module None id)
+    begin match mb.mb_id with
+    | None -> None
+    | Some id ->
+      let deprecated = Type_utils.is_deprecated mb.mb_attributes in
+      Some (mk ~children ~location ~deprecated `Module None id)
     end
   | Module_type_declaration mtd ->
     let children = get_mod_children ~include_types node in
@@ -155,8 +152,8 @@ and get_class_elements node =
   | Class_structure _ ->
     List.filter_map (Lazy.force node.t_children) ~f:(fun child ->
         match child.t_node with
-        | Class_field cf -> begin
-          match get_class_field_desc_infos cf.cf_desc with
+        | Class_field cf ->
+          begin match get_class_field_desc_infos cf.cf_desc with
           | Some (str_loc, outline_kind) ->
             let deprecated = Type_utils.is_deprecated cf.cf_attributes in
             Some
@@ -168,7 +165,7 @@ and get_class_elements node =
                 deprecated
               }
           | None -> None
-        end
+          end
         | _ -> None)
   | _ -> []
 

--- a/src/analysis/polarity_search.ml
+++ b/src/analysis/polarity_search.ml
@@ -19,11 +19,11 @@ let rec normalize_path env path =
     match decl.Types.type_manifest with
     | Some body
       when decl.Types.type_private = Asttypes.Public
-           || not (Btype.type_kind_is_abstract decl) -> begin
-      match Types.get_desc body with
+           || not (Btype.type_kind_is_abstract decl) ->
+      begin match Types.get_desc body with
       | Types.Tconstr (path, _, _) -> normalize_path env path
       | _ -> path
-    end
+      end
     | _ -> path)
 
 let match_query env query t =
@@ -34,16 +34,15 @@ let match_query env query t =
     match Types.get_desc t with
     | Types.Tconstr (path, params, _) ->
       remove cost pos (normalize_path env path);
-      begin
-        match Env.find_type path env with
-        | exception Not_found -> ()
-        | { Types.type_variance; _ } ->
-          List.iter2 type_variance params ~f:(fun var arg ->
-              if Types.Variance.mem Types.Variance.Inj var then (
-                if Types.Variance.mem Types.Variance.Pos var then
-                  traverse neg neg_fun pos pos_fun arg;
-                if Types.Variance.mem Types.Variance.Neg var then
-                  traverse pos pos_fun neg neg_fun arg))
+      begin match Env.find_type path env with
+      | exception Not_found -> ()
+      | { Types.type_variance; _ } ->
+        List.iter2 type_variance params ~f:(fun var arg ->
+            if Types.Variance.mem Types.Variance.Inj var then (
+              if Types.Variance.mem Types.Variance.Pos var then
+                traverse neg neg_fun pos pos_fun arg;
+              if Types.Variance.mem Types.Variance.Neg var then
+                traverse pos pos_fun neg neg_fun arg))
       end
     | Types.Tarrow (_, t1, t2, _) ->
       decr pos_fun;
@@ -155,15 +154,15 @@ let execute_query query env dirs =
 let execute_query_as_type_search ?(limit = 100) ~env ~query ~modules () =
   execute_query query env modules
   |> List.map ~f:(fun (cost, path, desc) ->
-         let name =
-           Printtyp.wrap_printing_env env @@ fun () ->
-           let path = Printtyp.rewrite_double_underscore_paths env path in
-           Format.asprintf "%a" Printtyp.Compat.path path
-         in
-         let doc = None in
-         let loc = desc.Types.val_loc in
-         let typ = desc.Types.val_type in
-         let constructible = Type_search.make_constructible name typ in
-         Query_protocol.{ cost; name; typ; loc; doc; constructible })
+      let name =
+        Printtyp.wrap_printing_env env @@ fun () ->
+        let path = Printtyp.rewrite_double_underscore_paths env path in
+        Format.asprintf "%a" Printtyp.Compat.path path
+      in
+      let doc = None in
+      let loc = desc.Types.val_loc in
+      let typ = desc.Types.val_type in
+      let constructible = Type_search.make_constructible name typ in
+      Query_protocol.{ cost; name; typ; loc; doc; constructible })
   |> List.sort ~cmp:Type_search.compare_result
   |> List.take_n limit

--- a/src/analysis/ptyp_of_type.ml
+++ b/src/analysis/ptyp_of_type.ml
@@ -182,7 +182,7 @@ and modes mode =
 and const_modalities ~mut modality =
   Printtyp.tree_of_modalities mut modality
   |> List.map ~f:(fun modality ->
-         Location.mknoloc (Parsetree.Modality modality))
+      Location.mknoloc (Parsetree.Modality modality))
 
 and value_description id
     { val_type; val_kind = _; val_loc; val_attributes; val_modalities; _ } =

--- a/src/analysis/stack_or_heap_enclosing.ml
+++ b/src/analysis/stack_or_heap_enclosing.ml
@@ -35,10 +35,10 @@ let from_nodes ~lsp_compat ~pos ~path =
     | ( Pattern { pat_desc = Tpat_var _; _ },
         Some
           (Value_binding
-            { vb_expr = { exp_desc = Texp_function { alloc_mode; _ }; _ };
-              vb_loc;
-              _
-            }) ) ->
+             { vb_expr = { exp_desc = Texp_function { alloc_mode; _ }; _ };
+               vb_loc;
+               _
+             }) ) ->
       (* The location that most sensibly corresponds to the "allocation" is the entire
          value binding. However, the LSP hover at this point will describe just the
          pattern, so we don't override the location in the [lsp_compat] regime. *)
@@ -113,7 +113,7 @@ let from_nodes ~lsp_compat ~pos ~path =
       | Texp_variant (_, maybe_exp_and_alloc_mode) ->
         maybe_exp_and_alloc_mode
         |> Option.map ~f:(fun (_, (alloc_mode : Typedtree.alloc_mode)) ->
-               alloc_mode)
+            alloc_mode)
         |> ret_maybe_alloc "variant without argument"
       | _ -> None)
     | _ -> None

--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -664,18 +664,18 @@ let get_oxcaml_syntax_doc cursor_loc nodes : syntax_info =
       List.find_opt modifiers ~f:(fun (modifier : _ Location.loc) ->
           Loc_comparison_result.is_inside (compare_cursor_to_loc modifier.loc))
       |> Option.bind ~f:(fun (modifier : _ Location.loc) ->
-             match modifier.txt with
-             | "non_pointer" ->
-               (Some
-                  { name = "Kind Modifier";
-                    description =
-                      "Modifies a value kind abbreviation to indicate that its \
-                       representation is never a pointer.";
-                    documentation = syntax_doc_url Oxcaml "kinds/syntax/";
-                    level = Advanced
-                  }
-                 : syntax_info)
-             | _ -> None))
+          match modifier.txt with
+          | "non_pointer" ->
+            (Some
+               { name = "Kind Modifier";
+                 description =
+                   "Modifies a value kind abbreviation to indicate that its \
+                    representation is never a pointer.";
+                 documentation = syntax_doc_url Oxcaml "kinds/syntax/";
+                 level = Advanced
+               }
+              : syntax_info)
+          | _ -> None))
   | Jkind_annotation { pjka_desc = Pjk_mod _; _ } :: _ ->
     Some
       { name = "`mod` keyword (in a kind)";
@@ -745,7 +745,8 @@ let get_oxcaml_syntax_doc cursor_loc nodes : syntax_info =
              match extra with
              | Typedtree.Texp_stack -> true
              | _ -> false)
-         && (* In this case, [exp_loc] differs from the location returned by
+         &&
+         (* In this case, [exp_loc] differs from the location returned by
                [Browse_raw.node_merlin_loc] (which is whats used to determine [nodes]).
                The [Browse_raw.node_merlin_loc] one includes the stack_, whereas [exp_loc]
                doesn't. Since we already know that the cursor is in the
@@ -832,7 +833,7 @@ let get_syntax_doc cursor_loc node : syntax_info =
     :: ( _,
          Module_type_constraint
            (Tmodtype_explicit
-             ({ mty_desc = Tmty_with (_, [ (_, _, Twith_modtype _) ]); _ }, _))
+              ({ mty_desc = Tmty_with (_, [ (_, _, Twith_modtype _) ]); _ }, _))
        )
     :: _ ->
     Some

--- a/src/analysis/tail_analysis.ml
+++ b/src/analysis/tail_analysis.ml
@@ -46,11 +46,11 @@ let tail_operator = function
   | _ -> false
 
 let expr_tail_positions = function
-  | Texp_apply (callee, args, _, _, _) when tail_operator callee -> begin
-    match List.last args with
+  | Texp_apply (callee, args, _, _, _) when tail_operator callee ->
+    begin match List.last args with
     | None | Some (_, Omitted _) -> []
     | Some (_, Arg (expr, _)) -> [ Expression expr ]
-  end
+    end
   | Texp_instvar _
   | Texp_setinstvar _
   | Texp_override _

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -85,11 +85,10 @@ let from_nodes ~path =
       with Jkind.Error.User_error _ -> None)
     | Class_field
         { cf_desc = Tcf_method (_, _, Tcfk_concrete (_, { exp_type })) } ->
-    begin
-      match Types.get_desc exp_type with
+      begin match Types.get_desc exp_type with
       | Tarrow (_, _, t, _) -> ret (Type (env, t))
       | _ -> None
-    end
+      end
     | Class_field
         { cf_desc = Tcf_val (_, _, _, Tcfk_concrete (_, { exp_type = t }), _) }
       -> ret (Type (env, t))

--- a/src/analysis/type_search.ml
+++ b/src/analysis/type_search.ml
@@ -135,8 +135,8 @@ let run ?(limit = 100) ~env ~query ~modules () =
   let init = compute_values query env None [] in
   modules
   |> List.fold_left ~init ~f:(fun acc name ->
-         let lident = Longident.Lident name in
-         values_from_module query env lident acc)
+      let lident = Longident.Lident name in
+      values_from_module query env lident acc)
   |> List.sort ~cmp:compare_result
   |> List.take_n limit
 

--- a/src/analysis/type_utils.ml
+++ b/src/analysis/type_utils.ml
@@ -178,31 +178,28 @@ let rec mod_smallerthan n (m : Subst.Lazy.module_type) =
       match List.length_lessthan n s with
       | None -> None
       | Some _ ->
-        List.fold_left s ~init:(Some 0)
-          ~f:
-            begin
-              fun acc item ->
-                let sub n1 m =
-                  match mod_smallerthan (n - n1) m with
-                  | Some n2 -> Some (n1 + n2)
-                  | None -> None
-                in
-                match (acc, si_modtype_opt item) with
-                | None, _ -> None
-                | Some n', _ when n' > n -> None
-                | Some n1, Some mty -> sub n1 mty
-                | Some n', _ -> Some (succ n')
-            end
-    end
-    | Mty_functor (m1, m2, _) -> begin
-      match (mod_smallerthan n m2, m1) with
+        List.fold_left s ~init:(Some 0) ~f:begin fun acc item ->
+            let sub n1 m =
+              match mod_smallerthan (n - n1) m with
+              | Some n2 -> Some (n1 + n2)
+              | None -> None
+            in
+            match (acc, si_modtype_opt item) with
+            | None, _ -> None
+            | Some n', _ when n' > n -> None
+            | Some n1, Some mty -> sub n1 mty
+            | Some n', _ -> Some (succ n')
+          end
+      end
+    | Mty_functor (m1, m2, _) ->
+      begin match (mod_smallerthan n m2, m1) with
       | None, _ -> None
       | result, Unit -> result
       | Some n1, Named (_, mt, _) -> (
         match mod_smallerthan (n - n1) mt with
         | None -> None
         | Some n2 -> Some (n1 + n2))
-    end
+      end
     | _ -> Some 1
 
 let print_short_modtype verbosity env ppf md =
@@ -218,8 +215,8 @@ let print_short_modtype verbosity env ppf md =
 let print_type_with_decl ~verbosity env ppf typ =
   match verbosity with
   | Verbosity.Smart | Lvl 0 -> Printtyp.type_scheme env ppf typ
-  | Lvl _ -> begin
-    match Types.get_desc typ with
+  | Lvl _ ->
+    begin match Types.get_desc typ with
     | Types.Tconstr (path, params, _) ->
       let decl = Env.with_cmis @@ fun () -> Env.find_type path env in
       let is_abstract = Btype.type_kind_is_abstract decl in
@@ -244,7 +241,7 @@ let print_type_with_decl ~verbosity env ppf typ =
           ~print_non_value_inferred_jkind:false
       end
     | _ -> Printtyp.type_scheme env ppf typ
-  end
+    end
 
 let print_exn ppf exn =
   match Location.error_of_exn exn with
@@ -254,13 +251,11 @@ let print_exn ppf exn =
 
 let print_type ppf verbosity env lid =
   let p, t = Env.find_type_by_name lid.Asttypes.txt env in
-  Printtyp.wrap_printing_env env ~verbosity
-    begin
-      fun () ->
-        Printtyp.type_declaration env
-          (Ident.create_persistent (* Incorrect, but doesn't matter. *)
-             (Path.last p))
-          ppf t
+  Printtyp.wrap_printing_env env ~verbosity begin fun () ->
+      Printtyp.type_declaration env
+        (Ident.create_persistent (* Incorrect, but doesn't matter. *)
+           (Path.last p))
+        ppf t
     end
 
 let print_modtype ppf verbosity env lid =
@@ -316,20 +311,19 @@ let type_in_env ?(verbosity = Verbosity.default) ?keywords ~context env ppf expr
     in
     let open Context in
     match extract_specific_parsing_info e with
-    | `Ident longident | `Constr longident -> begin
-      try
-        begin
-          match context with
-          | Label (lbl_des, _) ->
-            (* We use information from the context because `Env.find_label_by_name`
+    | `Ident longident | `Constr longident ->
+      begin try
+        begin match context with
+        | Label (lbl_des, _) ->
+          (* We use information from the context because `Env.find_label_by_name`
                can fail *)
-            Printtyp.Compat.type_expr ppf lbl_des.lbl_arg
-          | Type -> print_type ppf verbosity env longident
-          (* TODO: special processing for module aliases ? *)
-          | Module_type -> print_modtype ppf verbosity env longident
-          | Module_path -> print_modpath ppf verbosity env longident
-          | Constructor _ -> print_constr ppf env longident
-          | _ -> raise Fallback
+          Printtyp.Compat.type_expr ppf lbl_des.lbl_arg
+        | Type -> print_type ppf verbosity env longident
+        (* TODO: special processing for module aliases ? *)
+        | Module_type -> print_modtype ppf verbosity env longident
+        | Module_path -> print_modpath ppf verbosity env longident
+        | Constructor _ -> print_constr ppf env longident
+        | _ -> raise Fallback
         end;
         true
       with _ -> (
@@ -354,7 +348,7 @@ let type_in_env ?(verbosity = Verbosity.default) ?keywords ~context env ppf expr
               with _ ->
                 print_exn ppf exn;
                 false))))
-    end
+      end
     | `Other -> (
       try
         print_expr e;

--- a/src/commands/new_commands.ml
+++ b/src/commands/new_commands.ml
@@ -117,19 +117,15 @@ let all_commands =
          this variable.\n\
          The return value has the shape `[{'start': position, 'end': \
          position}, content]`, where content is string.\n"
-      ~default:(`Offset (-1), `Offset (-1))
-      begin
-        fun buffer -> function
-          | `Offset -1, _ -> failwith "-start <pos> is mandatory"
-          | _, `Offset -1 -> failwith "-end <pos> is mandatory"
-          | startp, endp ->
-            run buffer (Query_protocol.Case_analysis (startp, endp))
+      ~default:(`Offset (-1), `Offset (-1)) begin fun buffer -> function
+      | `Offset -1, _ -> failwith "-start <pos> is mandatory"
+      | _, `Offset -1 -> failwith "-end <pos> is mandatory"
+      | startp, endp -> run buffer (Query_protocol.Case_analysis (startp, endp))
       end;
     command "holes" ~spec:[]
       ~doc:"Returns the list of the positions of all the holes in the file."
-      ~default:()
-      begin
-        fun buffer () -> run buffer Query_protocol.Holes
+      ~default:() begin fun buffer () ->
+        run buffer Query_protocol.Holes
       end;
     command "construct"
       ~spec:
@@ -159,12 +155,11 @@ let all_commands =
          results of\n\
          inferior depth will not be returned."
       ~default:(`Offset (-1), None, None)
-      begin
-        fun buffer (pos, with_values, max_depth) ->
-          match pos with
-          | `Offset -1 -> failwith "-position <pos> is mandatory"
-          | pos ->
-            run buffer (Query_protocol.Construct (pos, with_values, max_depth))
+      begin fun buffer (pos, with_values, max_depth) ->
+      match pos with
+      | `Offset -1 -> failwith "-position <pos> is mandatory"
+      | pos ->
+        run buffer (Query_protocol.Construct (pos, with_values, max_depth))
       end;
     command "complete-prefix"
       ~spec:
@@ -216,14 +211,12 @@ let all_commands =
          - optional information which might not fit in the completion box, \
          like signatures for modules or documentation string."
       ~default:("", `None, [], false, true)
-      begin
-        fun buffer (txt, pos, kinds, doc, typ) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer
-              (Query_protocol.Complete_prefix
-                 (txt, pos, List.rev kinds, doc, typ))
+      begin fun buffer (txt, pos, kinds, doc, typ) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer
+          (Query_protocol.Complete_prefix (txt, pos, List.rev kinds, doc, typ))
       end;
     command "document"
       ~doc:
@@ -237,14 +230,11 @@ let all_commands =
             (marg_position (fun pos (ident, _pos) -> (ident, pos)));
           optional "-identifier" "<string> Identifier"
             (Marg.param "string" (fun ident (_ident, pos) -> (Some ident, pos)))
-        ]
-      ~default:(None, `None)
-      begin
-        fun buffer (ident, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Document (ident, pos))
+        ] ~default:(None, `None) begin fun buffer (ident, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Document (ident, pos))
       end;
     command "syntax-document"
       ~doc:
@@ -252,27 +242,20 @@ let all_commands =
       ~spec:
         [ arg "-position" "<position> Position to complete"
             (marg_position (fun pos _pos -> pos))
-        ]
-      ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Syntax_document pos)
+        ] ~default:`None begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Syntax_document pos)
       end;
     command "expand-ppx" ~doc:"Returns the generated code of a PPX."
       ~spec:
         [ arg "-position" "<position> Position to expand"
             (marg_position (fun pos _pos -> pos))
-        ]
-      ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Expand_ppx pos)
+        ] ~default:`None begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> run buffer (Query_protocol.Expand_ppx pos)
       end;
     command "enclosing"
       ~spec:
@@ -283,14 +266,10 @@ let all_commands =
         "Returns a list of locations `{'start': position, 'end': position}` in \
          increasing size of all entities surrounding the position.\n\
          (In a lisp, this would be the locations of all s-exps that contain \
-         the cursor.)"
-      ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Enclosing pos)
+         the cursor.)" ~default:`None begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> run buffer (Query_protocol.Enclosing pos)
       end;
     command "errors"
       ~spec:
@@ -321,10 +300,8 @@ let all_commands =
          Merlin was expecting such an error to be possible or not, and is \
          useful for debugging purposes.\n\
          `message` is the error description to be shown to the user."
-      ~default:(true, true, true)
-      begin
-        fun buffer (lexing, parsing, typing) ->
-          run buffer (Query_protocol.Errors { lexing; parsing; typing })
+      ~default:(true, true, true) begin fun buffer (lexing, parsing, typing) ->
+      run buffer (Query_protocol.Errors { lexing; parsing; typing })
       end;
     command "expand-prefix"
       ~doc:
@@ -353,15 +330,13 @@ let all_commands =
              cursor context"
             (marg_completion_kind (fun kind (txt, pos, kinds, typ) ->
                  (txt, pos, kind :: kinds, typ)))
-        ]
-      ~default:("", `None, [], false)
-      begin
-        fun buffer (txt, pos, kinds, typ) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer
-              (Query_protocol.Expand_prefix (txt, pos, List.rev kinds, typ))
+        ] ~default:("", `None, [], false)
+      begin fun buffer (txt, pos, kinds, typ) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer
+          (Query_protocol.Expand_prefix (txt, pos, List.rev kinds, typ))
       end;
     command "extension-list"
       ~spec:
@@ -376,25 +351,20 @@ let all_commands =
         ]
       ~doc:
         "List all known / currently enabled / currently disabled extensions as \
-         a list of strings."
-      ~default:`All
-      begin
-        fun buffer status -> run buffer (Query_protocol.Extension_list status)
+         a list of strings." ~default:`All begin fun buffer status ->
+      run buffer (Query_protocol.Extension_list status)
       end;
     command "findlib-list"
       ~doc:"Returns all known findlib packages as a list of string." ~spec:[]
-      ~default:()
-      begin
-        fun buffer () -> run buffer Query_protocol.Findlib_list
+      ~default:() begin fun buffer () ->
+        run buffer Query_protocol.Findlib_list
       end;
     command "flags-list" ~spec:[]
       ~doc:
         "Returns supported compiler flags.The purpose of this command is to \
          implement interactive completion of compiler settings in an IDE."
-      ~default:()
-      begin
-        fun _ () ->
-          `List (List.map ~f:Json.string (Mconfig.flags_for_completion ()))
+      ~default:() begin fun _ () ->
+        `List (List.map ~f:Json.string (Mconfig.flags_for_completion ()))
       end;
     command "jump"
       ~spec:
@@ -409,13 +379,11 @@ let all_commands =
          'module', 'module-type' and 'match' words.\n\
          It returns the starting position of the function, let definition, \
          module or match expression that contains the cursor\n"
-      ~default:("", `None)
-      begin
-        fun buffer (target, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Jump (target, pos))
+      ~default:("", `None) begin fun buffer (target, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Jump (target, pos))
       end;
     command "phrase"
       ~spec:
@@ -430,14 +398,12 @@ let all_commands =
         ]
       ~doc:
         "Returns the position of the next or previous phrase (top-level \
-         definition or module definition)."
-      ~default:(`Next, `None)
-      begin
-        fun buffer (target, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Phrase (target, pos))
+         definition or module definition)." ~default:(`Next, `None)
+      begin fun buffer (target, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Phrase (target, pos))
       end;
     command "list-modules"
       ~spec:
@@ -446,11 +412,9 @@ let all_commands =
         ]
       ~doc:
         "Looks into project source paths for files with an extension matching \
-         and prints the corresponding module name."
-      ~default:[]
-      begin
-        fun buffer extensions ->
-          run buffer (Query_protocol.List_modules (List.rev extensions))
+         and prints the corresponding module name." ~default:[]
+      begin fun buffer extensions ->
+      run buffer (Query_protocol.List_modules (List.rev extensions))
       end;
     command "locate"
       ~spec:
@@ -491,14 +455,12 @@ let all_commands =
          - if location failed, a `string` describing the reason to the user,\n\
          - `{'pos': position}` if the location is in the current buffer,\n\
          - `{'file': string, 'pos': position}` if definition is located in a \
-         different file."
-      ~default:(None, `None, `MLI, None)
-      begin
-        fun buffer (prefix, pos, lookfor, context) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Locate (prefix, lookfor, pos, context))
+         different file." ~default:(None, `None, `MLI, None)
+      begin fun buffer (prefix, pos, lookfor, context) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Locate (prefix, lookfor, pos, context))
       end;
     command "locate-type"
       ~spec:
@@ -506,12 +468,10 @@ let all_commands =
             (marg_position (fun pos _ -> pos))
         ]
       ~doc:"Locate the declaration of the type of the expression" ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Locate_type pos)
+      begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> run buffer (Query_protocol.Locate_type pos)
       end;
     command "locate-types"
       ~spec:
@@ -521,14 +481,10 @@ let all_commands =
       ~doc:
         "Locate the declaration of the type of the expression. If the type is \
          expressed via multiple identifiers, it returns the location of each \
-         identifier."
-      ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Locate_types pos)
+         identifier." ~default:`None begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> run buffer (Query_protocol.Locate_types pos)
       end;
     command "occurrences"
       ~spec:
@@ -545,13 +501,10 @@ let all_commands =
       ~doc:
         "Returns a list of locations `{'start': position, 'end': position}` of \
          all occurrences in current buffer of the entity at the specified \
-         position."
-      ~default:(`None, `Buffer)
-      begin
-        fun buffer -> function
-          | `None, _ -> failwith "-identifier-at <pos> is mandatory"
-          | `Ident_at pos, scope ->
-            run buffer (Query_protocol.Occurrences (`Ident_at pos, scope))
+         position." ~default:(`None, `Buffer) begin fun buffer -> function
+      | `None, _ -> failwith "-identifier-at <pos> is mandatory"
+      | `Ident_at pos, scope ->
+        run buffer (Query_protocol.Occurrences (`Ident_at pos, scope))
       end;
     command "outline"
       ~spec:
@@ -563,11 +516,8 @@ let all_commands =
       ~doc:
         "Returns a tree of objects `{'start': position, 'end': position, \
          'name': string, 'kind': string, 'children': subnodes}` describing the \
-         content of the buffer."
-      ~default:true
-      begin
-        fun buffer include_types ->
-          run buffer (Query_protocol.Outline { include_types })
+         content of the buffer." ~default:true begin fun buffer include_types ->
+      run buffer (Query_protocol.Outline { include_types })
       end;
     command "path-of-source"
       ~doc:
@@ -576,11 +526,8 @@ let all_commands =
       ~spec:
         [ arg "-file" "<filename> filename to look for in project paths"
             (Marg.param "filename" (fun file files -> file :: files))
-        ]
-      ~default:[]
-      begin
-        fun buffer filenames ->
-          run buffer (Query_protocol.Path_of_source (List.rev filenames))
+        ] ~default:[] begin fun buffer filenames ->
+      run buffer (Query_protocol.Path_of_source (List.rev filenames))
       end;
     command "refactor-open"
       ~doc:"refactor-open -position pos -action <qualify|unqualify>\n\tTODO"
@@ -593,14 +540,11 @@ let all_commands =
                  | "qualify" -> (Some `Qualify, pos)
                  | "unqualify" -> (Some `Unqualify, pos)
                  | _ -> failwith "invalid -action"))
-        ]
-      ~default:(None, `None)
-      begin
-        fun buffer -> function
-          | None, _ -> failwith "-action is mandatory"
-          | _, `None -> failwith "-position is mandatory"
-          | Some action, (#Msource.position as pos) ->
-            run buffer (Query_protocol.Refactor_open (action, pos))
+        ] ~default:(None, `None) begin fun buffer -> function
+      | None, _ -> failwith "-action is mandatory"
+      | _, `None -> failwith "-position is mandatory"
+      | Some action, (#Msource.position as pos) ->
+        run buffer (Query_protocol.Refactor_open (action, pos))
       end;
     command "search-by-polarity"
       ~doc:"search-by-polarity -position pos -query ident\n\tTODO"
@@ -609,14 +553,11 @@ let all_commands =
             (marg_position (fun pos (query, _pos) -> (query, pos)));
           arg "-query" "<string> Query of the form TODO"
             (Marg.param "string" (fun query (_prefix, pos) -> (query, pos)))
-        ]
-      ~default:("", `None)
-      begin
-        fun buffer (query, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Polarity_search (query, pos))
+        ] ~default:("", `None) begin fun buffer (query, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Polarity_search (query, pos))
       end;
     command "search-by-type" ~doc:"return a list of values that match a query"
       ~spec:
@@ -633,18 +574,15 @@ let all_commands =
           optional "-with-doc" "<bool> include docstring (default is false)"
             (Marg.bool (fun with_doc (query, pos, limit, _with_doc) ->
                  (query, pos, limit, with_doc)))
-        ]
-      ~default:(None, `None, 100, false)
-      begin
-        fun buffer (query, pos, limit, with_doc) ->
-          match (query, pos) with
-          | None, `None ->
-            failwith "-position <pos> and -query <string> are mandatory"
-          | None, _ -> failwith "-query <string> is mandatory"
-          | _, `None -> failwith "-position <pos> is mandatory"
-          | Some query, (#Msource.position as pos) ->
-            run buffer
-              (Query_protocol.Type_search (query, pos, limit, with_doc))
+        ] ~default:(None, `None, 100, false)
+      begin fun buffer (query, pos, limit, with_doc) ->
+      match (query, pos) with
+      | None, `None ->
+        failwith "-position <pos> and -query <string> are mandatory"
+      | None, _ -> failwith "-query <string> is mandatory"
+      | _, `None -> failwith "-position <pos> is mandatory"
+      | Some query, (#Msource.position as pos) ->
+        run buffer (Query_protocol.Type_search (query, pos, limit, with_doc))
       end;
     command "inlay-hints"
       ~doc:"return a list of inly-hints for additional client (like LSP)"
@@ -675,19 +613,20 @@ let all_commands =
             (Marg.bool
                (fun ghost (start, stop, let_binding, pattern_binding, _ghost) ->
                  (start, stop, let_binding, pattern_binding, ghost)))
-        ]
-      ~default:(`None, `None, false, false, true)
-      begin
-        fun buffer (start, stop, let_binding, pattern_binding, avoid_ghost) ->
-          match (start, stop) with
-          | `None, `None -> failwith "-start <pos> and -end are mandatory"
-          | `None, _ -> failwith "-start <pos> is mandatory"
-          | _, `None -> failwith "-end <pos> is mandatory"
-          | (#Msource.position, #Msource.position) as position ->
-            let start, stop = position in
-            run buffer
-              (Query_protocol.Inlay_hints
-                 (start, stop, let_binding, pattern_binding, avoid_ghost))
+        ] ~default:(`None, `None, false, false, true)
+      begin fun
+        buffer
+        (start, stop, let_binding, pattern_binding, avoid_ghost)
+      ->
+      match (start, stop) with
+      | `None, `None -> failwith "-start <pos> and -end are mandatory"
+      | `None, _ -> failwith "-start <pos> is mandatory"
+      | _, `None -> failwith "-end <pos> is mandatory"
+      | (#Msource.position, #Msource.position) as position ->
+        let start, stop = position in
+        run buffer
+          (Query_protocol.Inlay_hints
+             (start, stop, let_binding, pattern_binding, avoid_ghost))
       end;
     command "shape"
       ~doc:
@@ -706,12 +645,9 @@ let all_commands =
       ~spec:
         [ arg "-position" "<position> Position "
             (marg_position (fun pos _pos -> pos))
-        ]
-      ~default:`None
-      begin
-        fun buffer -> function
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos -> run buffer (Query_protocol.Shape pos)
+        ] ~default:`None begin fun buffer -> function
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos -> run buffer (Query_protocol.Shape pos)
       end;
     command "stack-or-heap-enclosing"
       ~doc:
@@ -762,15 +698,13 @@ let all_commands =
                  match int_of_string index with
                  | index -> (expr, cursor, pos, lsp_compat, Some index)
                  | exception _ -> failwith "index should be an integer"))
-        ]
-      ~default:("", -1, `None, false, None)
-      begin
-        fun buffer (_, _, pos, lsp_compat, index) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer
-              (Query_protocol.Stack_or_heap_enclosing (pos, lsp_compat, index))
+        ] ~default:("", -1, `None, false, None)
+      begin fun buffer (_, _, pos, lsp_compat, index) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer
+          (Query_protocol.Stack_or_heap_enclosing (pos, lsp_compat, index))
       end;
     command "type-enclosing"
       ~doc:
@@ -814,22 +748,18 @@ let all_commands =
                  match int_of_string index with
                  | index -> (expr, cursor, pos, Some index)
                  | exception _ -> failwith "index should be an integer"))
-        ]
-      ~default:("", -1, `None, None)
-      begin
-        fun buffer (expr, cursor, pos, index) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            let expr =
-              if expr = "" then None
-              else
-                let cursor =
-                  if cursor = -1 then String.length expr else cursor
-                in
-                Some (expr, cursor)
-            in
-            run buffer (Query_protocol.Type_enclosing (expr, pos, index))
+        ] ~default:("", -1, `None, None)
+      begin fun buffer (expr, cursor, pos, index) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        let expr =
+          if expr = "" then None
+          else
+            let cursor = if cursor = -1 then String.length expr else cursor in
+            Some (expr, cursor)
+        in
+        run buffer (Query_protocol.Type_enclosing (expr, pos, index))
       end;
     command "kind-enclosing"
       ~doc:
@@ -855,16 +785,13 @@ let all_commands =
                  match int_of_string index with
                  | index -> (pos, Some index)
                  | exception _ -> failwith "index should be an integer"))
-        ]
-      ~default:(`None, None)
-      begin
-        fun buffer (pos, index) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as position ->
-            run buffer
-              (Query_protocol.Kind_enclosing
-                 { position; index; override_verbosity = None })
+        ] ~default:(`None, None) begin fun buffer (pos, index) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as position ->
+        run buffer
+          (Query_protocol.Kind_enclosing
+             { position; index; override_verbosity = None })
       end;
     command "mode-enclosing"
       ~doc:
@@ -881,16 +808,12 @@ let all_commands =
       ~spec:
         [ arg "-position" "<position> Position to complete"
             (marg_position (fun pos _pos -> pos))
-        ]
-      ~default:`None
-      begin
-        fun buffer pos ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as position ->
-            run buffer
-              (Query_protocol.Mode_enclosing
-                 { position; override_verbosity = None })
+        ] ~default:`None begin fun buffer pos ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as position ->
+        run buffer
+          (Query_protocol.Mode_enclosing { position; override_verbosity = None })
       end;
     command "type-expression"
       ~doc:
@@ -901,14 +824,11 @@ let all_commands =
             (marg_position (fun pos (expr, _pos) -> (expr, pos)));
           arg "-expression" "<string> Expression to type"
             (Marg.param "string" (fun expr (_expr, pos) -> (expr, pos)))
-        ]
-      ~default:("", `None)
-      begin
-        fun buffer (expr, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as pos ->
-            run buffer (Query_protocol.Type_expr (expr, pos))
+        ] ~default:("", `None) begin fun buffer (expr, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as pos ->
+        run buffer (Query_protocol.Type_expr (expr, pos))
       end;
     (* Implemented without support from Query_protocol.  This command might be
        refactored if it proves useful for old protocol too. *)
@@ -921,53 +841,47 @@ let all_commands =
         \  'dot_merlins': [path], // a list of string\n\
         \  'failures': [message]  // a list of string\n\
          }\n\
-         ```"
-      ~default:()
-      begin
-        fun pipeline () ->
-          let config = Mpipeline.final_config pipeline in
-          `Assoc
-            [ (* TODO Remove support for multiple configuration files
+         ```" ~default:() begin fun pipeline () ->
+        let config = Mpipeline.final_config pipeline in
+        `Assoc
+          [ (* TODO Remove support for multiple configuration files
                  The protocol could be changed to:
                  'config_file': path_to_dot_merlin_or_dune
 
                  For now, if the configurator is dune, the field 'dot_merlins'
                  will contain the path to the dune file (or jbuild, or dune-project)
               *)
-              ( "dot_merlins",
-                `List
-                  (match Mconfig.(config.merlin.config_path) with
-                  | Some path -> [ Json.string path ]
-                  | None -> []) );
-              ( "failures",
-                `List (List.map ~f:Json.string Mconfig.(config.merlin.failures))
-              )
-            ]
+            ( "dot_merlins",
+              `List
+                (match Mconfig.(config.merlin.config_path) with
+                | Some path -> [ Json.string path ]
+                | None -> []) );
+            ( "failures",
+              `List (List.map ~f:Json.string Mconfig.(config.merlin.failures))
+            )
+          ]
       end;
     command "signature-help" ~doc:"Returns LSP Signature Help response"
       ~spec:
         [ arg "-position" "<position> Position of Signature Help request"
             (marg_position (fun pos (expr, _pos) -> (expr, pos)))
-        ]
-      ~default:("", `None)
-      begin
-        fun buffer (_, pos) ->
-          match pos with
-          | `None -> failwith "-position <pos> is mandatory"
-          | #Msource.position as position ->
-            let sh =
-              { Query_protocol.position;
-                trigger_kind = None;
-                is_retrigger = false;
-                active_signature_help = None
-              }
-            in
-            run buffer (Query_protocol.Signature_help sh)
+        ] ~default:("", `None) begin fun buffer (_, pos) ->
+      match pos with
+      | `None -> failwith "-position <pos> is mandatory"
+      | #Msource.position as position ->
+        let sh =
+          { Query_protocol.position;
+            trigger_kind = None;
+            is_retrigger = false;
+            active_signature_help = None
+          }
+        in
+        run buffer (Query_protocol.Signature_help sh)
       end;
     (* Used only for testing *)
     command "version" ~spec:[] ~default:() ~doc:"Print version information"
-      begin
-        fun buffer () -> run buffer Query_protocol.Version
+      begin fun buffer () ->
+        run buffer Query_protocol.Version
       end;
     (* Used only for testing *)
     command "dump"
@@ -976,15 +890,14 @@ let all_commands =
             "<source|parsetree|ppxed-source|ppxed-parsetree|typedtree|env|fullenv|browse|tokens|flags|warnings|exn|paths|hidden-paths> \
              Information to dump ()"
             (Marg.param "string" (fun what _ -> what))
-        ]
-      ~default:"" ~doc:"Not for the casual user, used for debugging merlin"
-      begin
-        fun pipeline what -> run pipeline (Query_protocol.Dump [ `String what ])
+        ] ~default:"" ~doc:"Not for the casual user, used for debugging merlin"
+      begin fun pipeline what ->
+      run pipeline (Query_protocol.Dump [ `String what ])
       end;
     (* Used only for testing *)
     command "dump-configuration" ~spec:[] ~default:()
       ~doc:"Not for the casual user, used for merlin tests"
-      begin
-        fun pipeline () -> Mconfig.dump (Mpipeline.final_config pipeline)
+      begin fun pipeline () ->
+        Mconfig.dump (Mpipeline.final_config pipeline)
       end
   ]

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -535,8 +535,8 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     `List
       (List.map locations ~f:(fun (name, loc) ->
            with_location loc [ ("content", `String name) ]))
-  | Document _, resp -> begin
-    match resp with
+  | Document _, resp ->
+    begin match resp with
     | `No_documentation -> `String "No documentation available"
     | `Invalid_context -> `String "Not a valid identifier"
     | `Builtin s ->
@@ -547,7 +547,7 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     | `Not_in_env str -> `String (Printf.sprintf "Not in environment '%s'" str)
     | `File_not_found msg -> `String msg
     | `Found doc -> `String doc
-  end
+    end
   | Syntax_document _, resp -> (
     match resp with
     | `Found { name; description; documentation; level } ->
@@ -581,11 +581,11 @@ let json_of_response (type a) (query : a t) (response : a) : json =
   | Locate_type _, resp -> json_of_locate resp
   | Locate_types _, resp -> json_of_locate_types resp
   | Locate _, resp -> json_of_locate resp
-  | Jump _, resp -> begin
-    match resp with
+  | Jump _, resp ->
+    begin match resp with
     | `Error str -> `String str
     | `Found pos -> `Assoc [ ("pos", Lexing.json_of_position pos) ]
-  end
+    end
   | Phrase _, pos -> `Assoc [ ("pos", Lexing.json_of_position pos) ]
   | Case_analysis _, ({ Location.loc_start; loc_end; _ }, str) ->
     let assoc =

--- a/src/config/gen_config.ml
+++ b/src/config/gen_config.ml
@@ -16,6 +16,6 @@ let ocamlversion :
   | `OCaml_4_07_0 | `OCaml_4_07_1 | `OCaml_4_08_0 | `OCaml_4_09_0
   | `OCaml_4_10_0 | `OCaml_4_11_0 | `OCaml_4_12_0 | `OCaml_4_13_0
   | `OCaml_4_14_0
-  | `OCaml_4_14_1 | `OCaml_5_0_0  | `OCaml_5_1_0 | `OCaml_5_2_0 ] = %s
+  | `OCaml_4_14_1 | `OCaml_5_0_0  | `OCaml_5_1_0 | `OCaml_5_2_0 | `OCaml_5_4_0 ] = %s
 |}
     ocaml_version_val

--- a/src/dot-merlin/dot_merlin_reader.ml
+++ b/src/dot-merlin/dot_merlin_reader.ml
@@ -41,10 +41,9 @@ let findlib_ok =
     in
     (* This is a quick and dirty workaround to get Merlin to work even when
        findlib directory has been removed. *)
-    begin
-      match Sys.getenv "OCAMLFIND_CONF" with
-      | exception Not_found -> Unix.putenv "OCAMLFIND_CONF" "/dev/null"
-      | _ -> ()
+    begin match Sys.getenv "OCAMLFIND_CONF" with
+    | exception Not_found -> Unix.putenv "OCAMLFIND_CONF" "/dev/null"
+    | _ -> ()
     end;
     Error ("Error during findlib initialization: " ^ message)
 
@@ -110,7 +109,7 @@ module Cache = File_cache.Make (struct
           | _ ->
             tell
               (`UNIT_NAME_FOR_ERROR
-                "Expected two arguments to UNIT_NAME_FOR directive")
+                 "Expected two arguments to UNIT_NAME_FOR directive")
         else if String.is_prefixed ~by:"WRAPPING_PREFIX " line then
           tell (`WRAPPING_PREFIX (String.drop 16 line))
         else if String.is_prefixed ~by:"FINDLIB " line then
@@ -217,20 +216,18 @@ let ppx_of_package ?(predicates = []) setup pkg =
            (Findlib.package_property predicates pkg "ppxopt"))
     with Not_found -> []
   in
-  begin
-    match ppx with
-    | None -> ()
-    | Some ppx -> log ~title:"ppx" "%s" ppx
+  begin match ppx with
+  | None -> ()
+  | Some ppx -> log ~title:"ppx" "%s" ppx
   end;
-  begin
-    match ppxopts with
-    | [] -> ()
-    | lst ->
-      log ~title:"ppx options" "%a" Logger.json @@ fun () ->
-      let f (ppx, opts) =
-        `List [ `String ppx; `List (List.map ~f:(fun s -> `String s) opts) ]
-      in
-      `List (List.map ~f lst)
+  begin match ppxopts with
+  | [] -> ()
+  | lst ->
+    log ~title:"ppx options" "%a" Logger.json @@ fun () ->
+    let f (ppx, opts) =
+      `List [ `String ppx; `List (List.map ~f:(fun s -> `String s) opts) ]
+    in
+    `List (List.map ~f lst)
   end;
   let setup =
     match ppx with
@@ -359,11 +356,10 @@ let prepend_config ~cwd ~cfg =
       | `PKG ps -> { cfg with packages_to_load = ps @ cfg.packages_to_load }
       | `STDLIB path ->
         let canon_path = canonicalize_filename ~cwd path in
-        begin
-          match cfg.stdlib with
-          | None -> ()
-          | Some p ->
-            log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
+        begin match cfg.stdlib with
+        | None -> ()
+        | Some p ->
+          log ~title:"conflicting paths for stdlib" "%s\n%s" p canon_path
         end;
         { cfg with stdlib = Some canon_path }
       | `SOURCE_ROOT path ->
@@ -371,22 +367,20 @@ let prepend_config ~cwd ~cfg =
         { cfg with source_root = Some canon_path }
       | `FINDLIB path ->
         let canon_path = canonicalize_filename ~cwd path in
-        begin
-          match cfg.stdlib with
-          | None -> ()
-          | Some p ->
-            log ~title:"conflicting paths for findlib" "%s\n%s" p canon_path
+        begin match cfg.stdlib with
+        | None -> ()
+        | Some p ->
+          log ~title:"conflicting paths for findlib" "%s\n%s" p canon_path
         end;
         { cfg with findlib = Some canon_path }
       | `FINDLIB_PATH path ->
         let canon_path = canonicalize_filename ~cwd path in
         { cfg with findlib_path = canon_path :: cfg.findlib_path }
       | `FINDLIB_TOOLCHAIN path ->
-        begin
-          match cfg.stdlib with
-          | None -> ()
-          | Some p ->
-            log ~title:"conflicting paths for findlib toolchain" "%s\n%s" p path
+        begin match cfg.stdlib with
+        | None -> ()
+        | Some p ->
+          log ~title:"conflicting paths for findlib toolchain" "%s\n%s" p path
         end;
         { cfg with findlib_toolchain = Some path })
 

--- a/src/dot-protocol/merlin_dot_protocol.ml
+++ b/src/dot-protocol/merlin_dot_protocol.ml
@@ -92,8 +92,8 @@ module Sexp = struct
 
   let to_directive sexp : directive =
     match sexp with
-    | List [ Atom tag; Atom value ] -> begin
-      match tag with
+    | List [ Atom tag; Atom value ] ->
+      begin match tag with
       | "S" -> `S value
       | "B" -> `B value
       | "SH" -> `SH value
@@ -112,7 +112,7 @@ module Sexp = struct
            But the protocole evolved, only dune 2.8 should be used *)
         `ERROR_MSG "No .merlin file found. Try building the project."
       | tag -> `UNKNOWN_TAG tag
-    end
+      end
     | List [ Atom "UNIT_NAME_FOR"; List [ Atom basename; Atom unit_name ] ] ->
       `UNIT_NAME_FOR { basename; unit_name }
     | List [ Atom "UNIT_NAME_FOR"; _ ] ->
@@ -121,12 +121,11 @@ module Sexp = struct
          UNIT_NAME_FOR"
     | List [ Atom tag; List l ] ->
       let value = strings_of_atoms l in
-      begin
-        match tag with
-        | "EXT" -> `EXT value
-        | "FLG" -> `FLG value
-        | "READER" -> `READER value
-        | tag -> `UNKNOWN_TAG tag
+      begin match tag with
+      | "EXT" -> `EXT value
+      | "FLG" -> `FLG value
+      | "READER" -> `READER value
+      | tag -> `UNKNOWN_TAG tag
       end
     | List [ Atom "EXCLUDE_QUERY_DIR" ] -> `EXCLUDE_QUERY_DIR
     | List [ Atom "USE_PPX_CACHE" ] -> `USE_PPX_CACHE

--- a/src/extend/extend_main.ml
+++ b/src/extend/extend_main.ml
@@ -137,16 +137,15 @@ end
 (** The main entry point of an extension. *)
 let extension_main ?reader desc =
   (* Check if invoked from Merlin *)
-  begin
-    match Sys.getenv "__MERLIN_MASTER_PID" with
-    | exception Not_found ->
-      Printf.eprintf
-        "This is %s merlin extension, version %s.\n\
-         This binary should be invoked from merlin and cannot be used directly.\n\
-         %!"
-        desc.P.name desc.P.version;
-      exit 1
-    | _ -> ()
+  begin match Sys.getenv "__MERLIN_MASTER_PID" with
+  | exception Not_found ->
+    Printf.eprintf
+      "This is %s merlin extension, version %s.\n\
+       This binary should be invoked from merlin and cannot be used directly.\n\
+       %!"
+      desc.P.name desc.P.version;
+    exit 1
+  | _ -> ()
   end;
   (* Communication happens on stdin/stdout. *)
   Handshake.negotiate { P.reader = reader <> None };

--- a/src/frontend/ocamlmerlin/new/new_merlin.ml
+++ b/src/frontend/ocamlmerlin/new/new_merlin.ml
@@ -163,10 +163,9 @@ let run =
               ]
           in
           log ~title:"run(result)" "%a" Logger.json (fun () -> json);
-          begin
-            match Mconfig.(config.merlin.protocol) with
-            | `Sexp -> Sexp.tell_sexp print_string (Sexp.of_json json)
-            | `Json -> Yojson.Basic.to_channel stdout json
+          begin match Mconfig.(config.merlin.protocol) with
+          | `Sexp -> Sexp.tell_sexp print_string (Sexp.of_json json)
+          | `Json -> Yojson.Basic.to_channel stdout json
           end;
           print_newline ()
         end
@@ -187,12 +186,11 @@ let with_wd ~wd ~old_wd f args =
     f args
 
 let run ~new_env wd args =
-  begin
-    match new_env with
-    | Some env ->
-      Os_ipc.merlin_set_environ env;
-      Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()))
-    | None -> ()
+  begin match new_env with
+  | Some env ->
+    Os_ipc.merlin_set_environ env;
+    Unix.putenv "__MERLIN_MASTER_PID" (string_of_int (Unix.getpid ()))
+  | None -> ()
   end;
   let old_wd = Sys.getcwd () in
   let run args () =

--- a/src/frontend/ocamlmerlin/old/old_IO.ml
+++ b/src/frontend/ocamlmerlin/old/old_IO.ml
@@ -46,13 +46,13 @@ let pos_of_json = function
   | `String "start" -> `Start
   | `String "end" -> `End
   | `Int offset -> `Offset offset
-  | `Assoc props -> begin
-    try
+  | `Assoc props ->
+    begin try
       match (List.assoc "line" props, List.assoc "col" props) with
       | `Int line, `Int col -> `Logical (line, col)
       | _ -> failwith "Incorrect position"
     with Not_found -> failwith "Incorrect position"
-  end
+    end
   | _ -> failwith "Incorrect position"
 
 let mandatory_position = function
@@ -271,12 +271,12 @@ let json_of_sync_command (type a) (command : a sync_command) (response : a) :
 let classify_response = function
   | Failure s | Exception (Failure s) -> ("failure", `String s)
   | Error error -> ("error", error)
-  | Exception exn -> begin
-    match Location.error_of_exn exn with
+  | Exception exn ->
+    begin match Location.error_of_exn exn with
     | Some (`Ok error) -> ("error", Query_json.json_of_error error)
     | None | Some `Already_displayed ->
       ("exception", `String (Printexc.to_string exn))
-  end
+    end
   | Return (Query cmd, response) ->
     ("return", Query_json.json_of_response cmd response)
   | Return (Sync cmd, response) -> ("return", json_of_sync_command cmd response)
@@ -343,21 +343,19 @@ let make_json ?(on_read = ignore) ~input ~output () =
 let make_sexp ?on_read ~input ~output () =
   (* Fix for emacs: emacs start-process doesn't distinguish between stdout and
      stderr.  So we redirect stderr to /dev/null with sexp frontend. *)
-  begin
-    match
-      begin
-        try Some (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o600)
-        with Unix.Unix_error _ ->
-          if Sys.os_type = "Win32" then
-            try Some (Unix.openfile "NUL" [ Unix.O_WRONLY ] 0o600)
-            with Unix.Unix_error _ -> None
-          else None
-      end
-    with
-    | None -> ()
-    | Some fd ->
-      Unix.dup2 fd Unix.stderr;
-      Unix.close fd
+  begin match
+    begin try Some (Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o600)
+    with Unix.Unix_error _ ->
+      if Sys.os_type = "Win32" then
+        try Some (Unix.openfile "NUL" [ Unix.O_WRONLY ] 0o600)
+        with Unix.Unix_error _ -> None
+      else None
+    end
+  with
+  | None -> ()
+  | Some fd ->
+    Unix.dup2 fd Unix.stderr;
+    Unix.close fd
   end;
   let input' = Sexp.of_file_descr ?on_read input in
   let input' () = Option.map ~f:Sexp.to_json (input' ()) in

--- a/src/frontend/ocamlmerlin/old/old_command.ml
+++ b/src/frontend/ocamlmerlin/old/old_command.ml
@@ -117,12 +117,11 @@ let checkout_buffer =
     try List.assoc document !checkout_buffer_cache
     with Not_found ->
       let buffer = new_buffer document in
-      begin
-        match document with
-        | Some _, _ ->
-          checkout_buffer_cache :=
-            (document, buffer) :: List.take_n cache_size !checkout_buffer_cache
-        | None, _ -> ()
+      begin match document with
+      | Some _, _ ->
+        checkout_buffer_cache :=
+          (document, buffer) :: List.take_n cache_size !checkout_buffer_cache
+      | None, _ -> ()
       end;
       buffer
 
@@ -182,12 +181,11 @@ let dispatch_sync config state (type a) : a sync_command -> a = function
           | _ -> true)
         state.customization
   | Protocol_version version ->
-    begin
-      match version with
-      | None -> ()
-      | Some 2 -> Old_IO.current_version := `V2
-      | Some 3 -> Old_IO.current_version := `V3
-      | Some _ -> ()
+    begin match version with
+    | None -> ()
+    | Some 2 -> Old_IO.current_version := `V2
+    | Some 3 -> Old_IO.current_version := `V3
+    | Some _ -> ()
     end;
     ( `Selected !Old_IO.current_version,
       `Latest Old_IO.latest_version,

--- a/src/frontend/ocamlmerlin/old/old_protocol.ml
+++ b/src/frontend/ocamlmerlin/old/old_protocol.ml
@@ -73,8 +73,8 @@ type _ sync_command =
   | Checkout : Context.document -> unit sync_command
   | Idle_job : bool sync_command
   | Flags_get : string list sync_command
-  | Project_get
-      : (string list * [ `Ok | `Failures of string list ]) sync_command
+  | Project_get :
+      (string list * [ `Ok | `Failures of string list ]) sync_command
 
 type 'a command = Query of 'a Query_protocol.t | Sync of 'a sync_command
 

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -73,40 +73,36 @@ let verbosity pipeline =
 let dump pipeline = function
   | [ `String "ppxed-source" ] ->
     let ppf, to_string = Format.to_string () in
-    begin
-      match Mpipeline.ppx_parsetree pipeline with
-      | `Interface s -> Pprintast.signature ppf s
-      | `Implementation s -> Pprintast.structure ppf s
+    begin match Mpipeline.ppx_parsetree pipeline with
+    | `Interface s -> Pprintast.signature ppf s
+    | `Implementation s -> Pprintast.structure ppf s
     end;
     Format.pp_print_newline ppf ();
     Format.pp_force_newline ppf ();
     `String (to_string ())
   | [ `String "source" ] ->
     let ppf, to_string = Format.to_string () in
-    begin
-      match Mpipeline.reader_parsetree pipeline with
-      | `Interface s -> Pprintast.signature ppf s
-      | `Implementation s -> Pprintast.structure ppf s
+    begin match Mpipeline.reader_parsetree pipeline with
+    | `Interface s -> Pprintast.signature ppf s
+    | `Implementation s -> Pprintast.structure ppf s
     end;
     Format.pp_print_newline ppf ();
     Format.pp_force_newline ppf ();
     `String (to_string ())
   | [ `String "parsetree" ] ->
     let ppf, to_string = Format.to_string () in
-    begin
-      match Mpipeline.reader_parsetree pipeline with
-      | `Interface s -> Printast.interface ppf s
-      | `Implementation s -> Printast.implementation ppf s
+    begin match Mpipeline.reader_parsetree pipeline with
+    | `Interface s -> Printast.interface ppf s
+    | `Implementation s -> Printast.implementation ppf s
     end;
     Format.pp_print_newline ppf ();
     Format.pp_force_newline ppf ();
     `String (to_string ())
   | [ `String "ppxed-parsetree" ] ->
     let ppf, to_string = Format.to_string () in
-    begin
-      match Mpipeline.ppx_parsetree pipeline with
-      | `Interface s -> Printast.interface ppf s
-      | `Implementation s -> Printast.implementation ppf s
+    begin match Mpipeline.ppx_parsetree pipeline with
+    | `Interface s -> Printast.interface ppf s
+    | `Implementation s -> Printast.implementation ppf s
     end;
     Format.pp_print_newline ppf ();
     Format.pp_force_newline ppf ();
@@ -122,12 +118,12 @@ let dump pipeline = function
           | `String "start" -> `Start
           | `String "end" -> `End
           | `Int offset -> `Offset offset
-          | `Assoc props -> begin
-            match (List.assoc "line" props, List.assoc "col" props) with
+          | `Assoc props ->
+            begin match (List.assoc "line" props, List.assoc "col" props) with
             | `Int line, `Int col -> `Logical (line, col)
             | _ -> failwith "Incorrect position"
             | exception Not_found -> failwith "Incorrect position"
-          end
+            end
           | _ -> failwith "Incorrect position")
       | [] -> None
       | _ -> failwith "incorrect position"
@@ -188,10 +184,9 @@ let dump pipeline = function
   | [ `String "typedtree" ] ->
     let tree = Mpipeline.typer_result pipeline |> Mtyper.get_typedtree in
     let ppf, to_string = Format.to_string () in
-    begin
-      match tree with
-      | `Interface s -> Printtyped.interface ppf s
-      | `Implementation s -> Printtyped.implementation ppf s
+    begin match tree with
+    | `Interface s -> Printtyped.interface ppf s
+    | `Implementation s -> Printtyped.implementation ppf s
     end;
     Format.pp_print_newline ppf ();
     Format.pp_force_newline ppf ();
@@ -225,8 +220,8 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     if
       not
       @@ List.exists errors ~f:(function
-           | Msupport.Warning _ -> false
-           | _ -> true)
+        | Msupport.Warning _ -> false
+        | _ -> true)
     then Typecore.optimise_allocations ();
 
     let pos = Mpipeline.get_lexing_pos pipeline pos in
@@ -442,33 +437,30 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
           | Browse_raw.Expression { exp_type = ty; _ }
           | Pattern { pat_type = ty; _ }
           | Core_type { ctyp_type = ty; _ }
-          | Value_description { val_desc = { ctyp_type = ty; _ }; _ } -> begin
-            match Types.get_desc ty with
+          | Value_description { val_desc = { ctyp_type = ty; _ }; _ } ->
+            begin match Types.get_desc ty with
             | Tconstr (path, _, _) -> Some (env, path)
             | _ -> None
-          end
+            end
           | _ -> None)
     in
-    begin
-      match path with
-      | None -> `Invalid_context
-      | Some (env, path) -> (
-        Locate.log ~title:"debug" "found type: %s" (Path.name path);
-        let config =
-          Locate.
-            { mconfig = Mpipeline.final_config pipeline;
-              ml_or_mli = `MLI;
-              traverse_aliases = true
-            }
-        in
-        match
-          Locate.from_path ~config ~env ~local_defs ~namespace:Type path
-        with
-        | `Builtin (_, s) -> `Builtin s
-        | `Not_in_env _ as s -> s
-        | `Not_found _ as s -> s
-        | `Found { file; location; _ } -> `Found (Some file, location.loc_start)
-        | `File_not_found { file = reason; _ } -> `File_not_found reason)
+    begin match path with
+    | None -> `Invalid_context
+    | Some (env, path) -> (
+      Locate.log ~title:"debug" "found type: %s" (Path.name path);
+      let config =
+        Locate.
+          { mconfig = Mpipeline.final_config pipeline;
+            ml_or_mli = `MLI;
+            traverse_aliases = true
+          }
+      in
+      match Locate.from_path ~config ~env ~local_defs ~namespace:Type path with
+      | `Builtin (_, s) -> `Builtin s
+      | `Not_in_env _ as s -> s
+      | `Not_found _ as s -> s
+      | `Found { file; location; _ } -> `Found (Some file, location.loc_start)
+      | `File_not_found { file = reason; _ } -> `File_not_found reason)
     end
   | Locate_types pos -> (
     let typer = Mpipeline.typer_result pipeline in
@@ -806,15 +798,14 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     in
     Destruct.log ~title:"nodes after" "%a" Logger.json (fun () ->
         `List (List.map nodes ~f:dump_node));
-    begin
-      match nodes with
-      | [] -> raise Destruct.Nothing_to_do
-      | (env, node) :: parents ->
-        let source = Mpipeline.input_source pipeline in
-        let config = Mpipeline.final_config pipeline in
-        let verbosity = verbosity pipeline in
-        Printtyp.wrap_printing_env env ~verbosity @@ fun () ->
-        Destruct.node config source node (List.map ~f:snd parents)
+    begin match nodes with
+    | [] -> raise Destruct.Nothing_to_do
+    | (env, node) :: parents ->
+      let source = Mpipeline.input_source pipeline in
+      let config = Mpipeline.final_config pipeline in
+      let verbosity = verbosity pipeline in
+      Printtyp.wrap_printing_env env ~verbosity @@ fun () ->
+      Destruct.node config source node (List.map ~f:snd parents)
     end
   | Holes ->
     let typer = Mpipeline.typer_result pipeline in
@@ -851,23 +842,22 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let typedtree = Mtyper.get_typedtree typer in
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let structures = Mbrowse.enclosing pos [ Mbrowse.of_typedtree typedtree ] in
-    begin
-      match structures with
-      | ( _,
-          (Browse_raw.Module_expr { mod_desc = Tmod_typed_hole; _ } as
-           node_for_loc) )
-        :: (_, node)
-        :: _parents ->
-        let loc = Mbrowse.node_loc node_for_loc in
-        (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
-      | ( _,
-          (Browse_raw.Expression { exp_desc = Texp_typed_hole | Texp_hole _; _ }
-           as node) )
-        :: _parents ->
-        let loc = Mbrowse.node_loc node in
-        (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
-      | _ :: _ -> raise Construct.Not_a_hole
-      | [] -> raise No_nodes
+    begin match structures with
+    | ( _,
+        (Browse_raw.Module_expr { mod_desc = Tmod_typed_hole; _ } as
+         node_for_loc) )
+      :: (_, node)
+      :: _parents ->
+      let loc = Mbrowse.node_loc node_for_loc in
+      (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
+    | ( _,
+        (Browse_raw.Expression { exp_desc = Texp_typed_hole | Texp_hole _; _ }
+         as node) )
+      :: _parents ->
+      let loc = Mbrowse.node_loc node in
+      (loc, Construct.node ~config ~keywords ?depth ~values_scope node)
+    | _ :: _ -> raise Construct.Not_a_hole
+    | [] -> raise No_nodes
     end
   | Outline { include_types } ->
     let typer = Mpipeline.typer_result pipeline in
@@ -917,13 +907,12 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let first_syntax_error = ref Lexing.dummy_pos in
     let filter_typer_error exn =
       let result = filter_error exn in
-      begin
-        match result with
-        | Some ({ Location.source = Location.Parser; _ } as err)
-          when !first_syntax_error = Lexing.dummy_pos
-               || Lexing.compare_pos !first_syntax_error (error_start err) > 0
-          -> first_syntax_error := error_start err
-        | _ -> ()
+      begin match result with
+      | Some ({ Location.source = Location.Parser; _ } as err)
+        when !first_syntax_error = Lexing.dummy_pos
+             || Lexing.compare_pos !first_syntax_error (error_start err) > 0 ->
+        first_syntax_error := error_start err
+      | _ -> ()
       end;
       result
     in
@@ -933,14 +922,13 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       | Msupport.Warning _ as exn -> filter_error exn
       | exn ->
         let result = filter_error exn in
-        begin
-          match result with
-          | None -> ()
-          | Some err ->
-            if
-              !first_syntax_error = Lexing.dummy_pos
-              || Lexing.compare_pos !first_syntax_error (error_start err) > 0
-            then first_syntax_error := error_start err
+        begin match result with
+        | None -> ()
+        | Some err ->
+          if
+            !first_syntax_error = Lexing.dummy_pos
+            || Lexing.compare_pos !first_syntax_error (error_start err) > 0
+          then first_syntax_error := error_start err
         end;
         result
     in
@@ -1008,14 +996,13 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
   | Extension_list kind ->
     let config = Mpipeline.final_config pipeline in
     let enabled = Mconfig.(config.merlin.extensions) in
-    begin
-      match kind with
-      | `All -> Extension.all
-      | `Enabled -> enabled
-      | `Disabled ->
-        List.fold_left
-          ~f:(fun exts ext -> List.remove ext exts)
-          ~init:Extension.all enabled
+    begin match kind with
+    | `All -> Extension.all
+    | `Enabled -> enabled
+    | `Disabled ->
+      List.fold_left
+        ~f:(fun exts ext -> List.remove ext exts)
+        ~init:Extension.all enabled
     end
   | Path_list `Build ->
     let config = Mpipeline.final_config pipeline in
@@ -1046,12 +1033,11 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let start = Mpipeline.get_lexing_pos pipeline start
     and stop = Mpipeline.get_lexing_pos pipeline stop in
     let typer_result = Mpipeline.typer_result pipeline in
-    begin
-      match Mtyper.get_typedtree typer_result with
-      | `Interface _ -> []
-      | `Implementation structure ->
-        Inlay_hints.of_structure ~hint_let_binding ~hint_pattern_binding
-          ~avoid_ghost_location ~start ~stop structure
+    begin match Mtyper.get_typedtree typer_result with
+    | `Interface _ -> []
+    | `Implementation structure ->
+      Inlay_hints.of_structure ~hint_let_binding ~hint_pattern_binding
+        ~avoid_ghost_location ~start ~stop structure
     end
   | Signature_help { position; _ } -> (
     (* Todo: additionnal contextual information could help us provide better

--- a/src/frontend/test/ocamlmerlin_test.ml
+++ b/src/frontend/test/ocamlmerlin_test.ml
@@ -168,27 +168,25 @@ let rec run_tests indent = function
 and run_test indent = function
   | Single (name, f) ->
     Printf.printf "%s%s:\t%!" indent name;
-    begin
-      match f () with
-      | () ->
-        incr passed;
-        Printf.printf "OK\n%!"
-      | exception exn ->
-        let bt = Printexc.get_backtrace () in
-        incr failed;
-        Printf.printf "KO\n%!";
-        Printf.eprintf "%sTest %s failed with exception:\n%s%s\n%!" indent name
-          indent
-          (match exn with
-          | Failure str -> str
-          | exn -> Printexc.to_string exn);
-        begin
-          match Location.error_of_exn exn with
-          | None | Some `Already_displayed -> ()
-          | Some (`Ok { Location.msg; loc }) ->
-            Printf.eprintf "%sError message:\n%s\n%!" indent msg
-        end;
-        Printf.eprintf "%sBacktrace:\n%s\n%!" indent bt
+    begin match f () with
+    | () ->
+      incr passed;
+      Printf.printf "OK\n%!"
+    | exception exn ->
+      let bt = Printexc.get_backtrace () in
+      incr failed;
+      Printf.printf "KO\n%!";
+      Printf.eprintf "%sTest %s failed with exception:\n%s%s\n%!" indent name
+        indent
+        (match exn with
+        | Failure str -> str
+        | exn -> Printexc.to_string exn);
+      begin match Location.error_of_exn exn with
+      | None | Some `Already_displayed -> ()
+      | Some (`Ok { Location.msg; loc }) ->
+        Printf.eprintf "%sError message:\n%s\n%!" indent msg
+      end;
+      Printf.eprintf "%sBacktrace:\n%s\n%!" indent bt
     end
   | Group (name, tests) ->
     Printf.printf "%s-> %s\n" indent name;

--- a/src/index-format/granular_map.ml
+++ b/src/index-format/granular_map.ml
@@ -74,30 +74,30 @@ module Make (Ord : Map.OrderedType) = struct
       | Empty -> 0
       | Node { h; _ } -> h
     in
-    if hl > hr + 2 then begin
-      match fetch l with
+    if hl > hr + 2 then
+      begin match fetch l with
       | Empty -> invalid_arg "Map.bal"
       | Node { l = ll; v = lv; d = ld; r = lr; _ } ->
         if height ll >= height lr then create ll lv ld (create lr x d r)
-        else begin
-          match fetch lr with
+        else
+          begin match fetch lr with
           | Empty -> invalid_arg "Map.bal"
           | Node { l = lrl; v = lrv; d = lrd; r = lrr; _ } ->
             create (create ll lv ld lrl) lrv lrd (create lrr x d r)
-        end
-    end
-    else if hr > hl + 2 then begin
-      match fetch r with
+          end
+      end
+    else if hr > hl + 2 then
+      begin match fetch r with
       | Empty -> invalid_arg "Map.bal"
       | Node { l = rl; v = rv; d = rd; r = rr; _ } ->
         if height rr >= height rl then create (create l x d rl) rv rd rr
-        else begin
-          match fetch rl with
+        else
+          begin match fetch rl with
           | Empty -> invalid_arg "Map.bal"
           | Node { l = rll; v = rlv; d = rld; r = rlr; _ } ->
             create (create l x d rll) rlv rld (create rlr rv rd rr)
-        end
-    end
+          end
+      end
     else
       link (Node { l; v = x; d; r; h = (if hl >= hr then hl + 1 else hr + 1) })
 
@@ -277,19 +277,19 @@ module Make (Ord : Map.OrderedType) = struct
 
   let rec update x f t =
     match fetch t with
-    | Empty -> begin
-      match f None with
+    | Empty ->
+      begin match f None with
       | None -> t
       | Some data -> link (Node { l = t; v = x; d = data; r = t; h = 1 })
-    end
+      end
     | Node { l; v; d; r; h } ->
       let c = Ord.compare x v in
-      if c = 0 then begin
-        match f (Some d) with
+      if c = 0 then
+        begin match f (Some d) with
         | None -> merge l r
         | Some data ->
           if d == data then t else link (Node { l; v = x; d = data; r; h })
-      end
+        end
       else if c < 0 then
         let ll = update x f l in
         if l == ll then t else bal ll v d r

--- a/src/index-format/granular_set.ml
+++ b/src/index-format/granular_set.ml
@@ -71,30 +71,30 @@ module Make (Ord : Set.OrderedType) = struct
       | Empty -> 0
       | Node { h; _ } -> h
     in
-    if hl > hr + 2 then begin
-      match fetch l with
+    if hl > hr + 2 then
+      begin match fetch l with
       | Empty -> invalid_arg "Set.bal"
       | Node { l = ll; v = lv; r = lr; _ } ->
         if height ll >= height lr then create ll lv (create lr v r)
-        else begin
-          match fetch lr with
+        else
+          begin match fetch lr with
           | Empty -> invalid_arg "Set.bal"
           | Node { l = lrl; v = lrv; r = lrr; _ } ->
             create (create ll lv lrl) lrv (create lrr v r)
-        end
-    end
-    else if hr > hl + 2 then begin
-      match fetch r with
+          end
+      end
+    else if hr > hl + 2 then
+      begin match fetch r with
       | Empty -> invalid_arg "Set.bal"
       | Node { l = rl; v = rv; r = rr; _ } ->
         if height rr >= height rl then create (create l v rl) rv rr
-        else begin
-          match fetch rl with
+        else
+          begin match fetch rl with
           | Empty -> invalid_arg "Set.bal"
           | Node { l = rll; v = rlv; r = rlr; _ } ->
             create (create l v rll) rlv (create rlr rv rr)
-        end
-    end
+          end
+      end
     else link (Node { l; v; r; h = (if hl >= hr then hl + 1 else hr + 1) })
 
   let empty = link Empty

--- a/src/index-format/union_find.ml
+++ b/src/index-format/union_find.ml
@@ -17,8 +17,8 @@ let union ~f x y =
   let x = find x in
   let y = find y in
   if x == y then x
-  else begin
-    match (!x, !y) with
+  else
+    begin match (!x, !y) with
     | ( Root ({ rank = rank_x; value = value_x } as root_x),
         Root ({ rank = rank_y; value = value_y } as root_y) ) ->
       let new_value = f value_x value_y in
@@ -32,7 +32,7 @@ let union ~f x y =
         if rank_x = rank_y then root_x.rank <- root_x.rank + 1;
         x)
     | _ -> assert false
-  end
+    end
 
 let get elt =
   match !(find elt) with

--- a/src/kernel/mconfig.ml
+++ b/src/kernel/mconfig.ml
@@ -912,13 +912,15 @@ let ocaml_flags =
         \        <num>             a single warning number\n\
         \        <num1>..<num2>    a range of consecutive warning numbers\n\
         \        <letter>          a predefined set\n\
-        \     default setting is %S" Warnings.defaults_w );
+        \     default setting is %S"
+        Warnings.defaults_w );
     ( "-warn-error",
       ocaml_warnings_spec ~error:true,
       Printf.sprintf
         "<list> Enable or disable error status for warnings according\n\
         \     to <list>.  See option -w for the syntax of <list>.\n\
-        \     Default setting is %S" Warnings.defaults_warn_error );
+        \     Default setting is %S"
+        Warnings.defaults_warn_error );
     ( "-alert",
       ocaml_alert_spec,
       Printf.sprintf
@@ -1177,11 +1179,10 @@ let unitname t =
   | None ->
     let basename = Misc.unitname t.query.filename in
     (* CR: get rid of wrapping_prefix. it is only here for legacy reasons at the moment *)
-    begin
-      match t.merlin.wrapping_prefix with
-      | Some prefix -> Misc.unitname (prefix ^ basename)
-      | None ->
-        String.Map.find_opt basename t.merlin.unit_name_for
-        |> Option.map ~f:Misc.unitname
-        |> Option.value ~default:basename
+    begin match t.merlin.wrapping_prefix with
+    | Some prefix -> Misc.unitname (prefix ^ basename)
+    | None ->
+      String.Map.find_opt basename t.merlin.unit_name_for
+      |> Option.map ~f:Misc.unitname
+      |> Option.value ~default:basename
     end

--- a/src/kernel/mconfig_dot.ml
+++ b/src/kernel/mconfig_dot.ml
@@ -258,7 +258,7 @@ end = struct
     | _ -> begin
       Hashtbl.remove running_processes (dir, configurator);
       raise Process_exited
-    end
+      end
 end
 
 let prepend_config ~dir:cwd configurator (directives : directive list) config =
@@ -359,12 +359,12 @@ let get_config { workdir; process_dir; configurator } path_abs =
     let path_rel =
       String.chop_prefix ~prefix:p.initial_cwd path_abs
       |> Option.map ~f:(fun path ->
-             (* We need to remove the leading path separator after chopping.
+          (* We need to remove the leading path separator after chopping.
                 There is one case where no separator is left: when [initial_cwd]
                 was the root of the filesystem *)
-             if String.length path > 0 && path.[0] = Filename.dir_sep.[0] then
-               String.drop 1 path
-             else path)
+          if String.length path > 0 && path.[0] = Filename.dir_sep.[0] then
+            String.drop 1 path
+          else path)
     in
 
     let path =

--- a/src/kernel/mppx.ml
+++ b/src/kernel/mppx.ml
@@ -12,11 +12,10 @@ let with_include_dir ~visible_path ~hidden_path f =
   Clflags.include_dirs := visible_path;
   Clflags.hidden_include_dirs := hidden_path;
   let result =
-    begin
-      try f ()
-      with e ->
-        restore ();
-        raise e
+    begin try f ()
+    with e ->
+      restore ();
+      raise e
     end
   in
   restore ();

--- a/src/kernel/mreader.ml
+++ b/src/kernel/mreader.ml
@@ -135,15 +135,14 @@ let print_pretty config source tree =
   | None ->
     let ppf, to_string = Std.Format.to_string () in
     let open Extend_protocol.Reader in
-    begin
-      match tree with
-      | Pretty_case_list x -> Pprintast.case_list ppf x
-      | Pretty_core_type x -> Pprintast.core_type ppf x
-      | Pretty_expression x -> Pprintast.expression ppf x
-      | Pretty_pattern x -> Pprintast.pattern ppf x
-      | Pretty_signature x -> Pprintast.signature ppf x
-      | Pretty_structure x -> Pprintast.structure ppf x
-      | Pretty_toplevel_phrase x -> Pprintast.toplevel_phrase ppf x
+    begin match tree with
+    | Pretty_case_list x -> Pprintast.case_list ppf x
+    | Pretty_core_type x -> Pprintast.core_type ppf x
+    | Pretty_expression x -> Pprintast.expression ppf x
+    | Pretty_pattern x -> Pprintast.pattern ppf x
+    | Pretty_signature x -> Pprintast.signature ppf x
+    | Pretty_structure x -> Pprintast.structure ppf x
+    | Pretty_toplevel_phrase x -> Pprintast.toplevel_phrase ppf x
     end;
     to_string ()
 
@@ -171,13 +170,16 @@ let reconstruct_identifier config source pos =
 (* Entry point *)
 
 let parse ?for_completion config = function
-  | source, None -> begin
-    match
+  | source, None ->
+    begin match
       try_with_reader config source (Mreader_extend.parse ?for_completion)
     with
     | Some (`No_labels no_labels_for_completion, parsetree) ->
       let lexer_errors, parser_errors, comments = ([], [], []) in
-      let lexer_keywords = [] (* TODO? *) in
+      let lexer_keywords =
+        []
+        (* TODO? *)
+      in
       { lexer_keywords;
         lexer_errors;
         parser_errors;
@@ -186,7 +188,7 @@ let parse ?for_completion config = function
         no_labels_for_completion
       }
     | None -> normal_parse ?for_completion config source
-  end
+    end
   | _, Some parsetree ->
     let lexer_errors, parser_errors, comments = ([], [], []) in
     let lexer_keywords = [] in

--- a/src/kernel/mreader_explain.ml
+++ b/src/kernel/mreader_explain.ml
@@ -57,13 +57,12 @@ let explain env (unexpected, startp, endp) popped shifted =
     | None -> return None
     | Some (Element (st, _, startp, endp)) -> (
       if closing_st st then incr closed;
-      begin
-        match opening_st st with
-        | None -> ()
-        | Some st ->
-          if !closed = 0 && !unclosed = None then
-            unclosed := Some (st, mkloc startp endp)
-          else decr closed
+      begin match opening_st st with
+      | None -> ()
+      | Some st ->
+        if !closed = 0 && !unclosed = None then
+          unclosed := Some (st, mkloc startp endp)
+        else decr closed
       end;
       match Parser_explain.named_item_at (number st) with
       | name -> return (Some (name, mkloc startp endp))

--- a/src/kernel/mreader_lexer.ml
+++ b/src/kernel/mreader_lexer.ml
@@ -331,11 +331,10 @@ let for_completion t pos =
     | (Triple (token, _, loc_end) as item) :: _ as items
       when Lexing.compare_pos pos loc_end = 0 ->
       check_label item;
-      begin
-        match token with
-        (* Already on identifier, no need to introduce *)
-        | UIDENT _ | LIDENT _ -> raise Exit
-        | _ -> (acc, items)
+      begin match token with
+      (* Already on identifier, no need to introduce *)
+      | UIDENT _ | LIDENT _ -> raise Exit
+      | _ -> (acc, items)
       end
     | items -> (acc, items)
   in

--- a/src/kernel/mreader_parser.ml
+++ b/src/kernel/mreader_parser.ml
@@ -87,8 +87,8 @@ let resume_parse =
         | [] -> (eof_token, [])
       in
       check_for_error acc token tokens env (I.offer checkpoint token)
-    | (I.Shifting (_, env, _) | I.AboutToReduce (env, _)) as checkpoint -> begin
-      match I.resume checkpoint with
+    | (I.Shifting (_, env, _) | I.AboutToReduce (env, _)) as checkpoint ->
+      begin match I.resume checkpoint with
       | checkpoint' -> normal acc tokens checkpoint'
       | exception exn ->
         Msupport.raise_error exn;
@@ -99,18 +99,18 @@ let resume_parse =
           | (_, token) :: _ -> token
         in
         enter_error acc token tokens env
-    end
+      end
     | I.Accepted v -> (acc, v)
     | I.Rejected | I.HandlingError _ -> assert false
   and check_for_error acc token tokens env = function
     | I.HandlingError _ -> enter_error acc token tokens env
-    | (I.Shifting _ | I.AboutToReduce _) as checkpoint -> begin
-      match I.resume checkpoint with
+    | (I.Shifting _ | I.AboutToReduce _) as checkpoint ->
+      begin match I.resume checkpoint with
       | checkpoint' -> check_for_error acc token tokens env checkpoint'
       | exception exn ->
         Msupport.raise_error exn;
         enter_error acc token tokens env
-    end
+      end
     | checkpoint ->
       normal ((Correct checkpoint, token) :: acc) tokens checkpoint
   and enter_error acc token tokens env =

--- a/src/kernel/mreader_recover.ml
+++ b/src/kernel/mreader_recover.ml
@@ -129,11 +129,11 @@ struct
               (env_state x.env) (let (t,_,_) = token in Dump.token t);*)
           aux xs
         | `Recovered (checkpoint, _) -> `Ok (checkpoint, x.env)
-        | `Accept v -> begin
-          match aux xs with
+        | `Accept v ->
+          begin match aux xs with
           | `Fail -> `Accept v
           | x -> x
-        end)
+          end)
     in
     aux recoveries
 
@@ -199,11 +199,10 @@ struct
             in
             let v = Recovery.default_value loc sym in
             let token = (Recovery.token_of_terminal t v, endp, endp) in
-            begin
-              match feed_token ~allow_reduction:true token env with
-              | `Fail -> assert false
-              | `Accept v -> raise (E.Result v)
-              | `Recovered (_, env) -> env
+            begin match feed_token ~allow_reduction:true token env with
+            | `Fail -> assert false
+            | `Accept v -> raise (E.Result v)
+            | `Recovered (_, env) -> env
             end
           | Recovery.Sub actions ->
             log ~title:"enter Sub" "";

--- a/src/kernel/mtyper.ml
+++ b/src/kernel/mtyper.ml
@@ -218,7 +218,7 @@ let type_interface config caught (parsetree : Parsetree.signature) =
     match cached_value with
     | Some
         (Interface_items
-          { items; psig_modalities; sig_modalities = _; sig_sloc = _ })
+           { items; psig_modalities; sig_modalities = _; sig_sloc = _ })
     (* only use the cached items if they were typed using the same modalities on the sig *)
       when List.equal
              ~eq:(fun

--- a/src/kernel/overrides.ml
+++ b/src/kernel/overrides.ml
@@ -144,17 +144,17 @@ let get_overrides ~attribute_name (ppx_parsetree : Mreader.parsetree) =
   in
   attributes
   |> List.concat_map ~f:(fun attribute ->
-         match of_attribute ~attribute_name attribute with
-         | Ok overrides -> overrides
-         | Error err ->
-           log ~title:"get_overrides" "%s" err;
-           [])
+      match of_attribute ~attribute_name attribute with
+      | Ok overrides -> overrides
+      | Error err ->
+        log ~title:"get_overrides" "%s" err;
+        [])
   |> List.filter_map ~f:(fun (override : _ Override.t) ->
-         match Override.to_interval override with
-         | Ok interval -> Some interval
-         | Error err ->
-           log ~title:"get_overrides" "%s" err;
-           None)
+      match Override.to_interval override with
+      | Ok interval -> Some interval
+      | Error err ->
+        log ~title:"get_overrides" "%s" err;
+        None)
   |> Overrides_interval_tree.of_alist
 
 let find t ~cursor = Overrides_interval_tree.find t cursor

--- a/src/ocaml-index/lib/index.ml
+++ b/src/ocaml-index/lib/index.ml
@@ -81,7 +81,7 @@ struct
       match artifact with
       | None -> None
       | Some artifact -> Merlin_analysis.Locate.Artifact.impl_shape artifact
-    end
+      end
 
   let read_unit_shape ~diagnostics:_ ~unit_name =
     Log.debug "Read unit shape: %s\n%!" unit_name;
@@ -114,7 +114,8 @@ let index_of_artifact ~into ~root ~rewrite_root ~build_path
   init_load_path_once ~do_not_use_cmt_loadpath ~dirs:build_path cmt_loadpath;
   let module Reduce = Shape_reduce.Make (Reduce_conf (struct
     let shapes = shapes
-  end)) in
+  end))
+  in
   let defs =
     gather_locs_from_fragments ~root ~rewrite_root into.defs uid_to_loc
   in
@@ -209,7 +210,7 @@ let index_of_cmt ~root ~build_path ~shapes ~store_shapes cmt_infos =
   let uid_to_loc =
     Shape.Uid.Tbl.to_list cmt_uid_to_decl
     |> List.map (fun (uid, fragment) ->
-           (uid, Typedtree_utils.location_of_declaration ~uid fragment))
+        (uid, Typedtree_utils.location_of_declaration ~uid fragment))
     |> Shape.Uid.Tbl.of_list
   in
   index_of_artifact ~root ~build_path ~shapes ~store_shapes ~cmt_loadpath

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -785,11 +785,11 @@ let of_node node =
     | Core_type { ctyp_desc } -> of_core_type_desc ctyp_desc
     | Package_type { pack_fields } ->
       list_fold (fun (_, ct) -> of_core_type ct) pack_fields
-    | Row_field rf -> begin
-      match rf.rf_desc with
+    | Row_field rf ->
+      begin match rf.rf_desc with
       | Ttag (_, _, cts) -> list_fold of_core_type cts
       | Tinherit ct -> of_core_type ct
-    end
+      end
     | Value_description { val_desc; val_modal_info } ->
       of_core_type val_desc ** of_value_description_modal_info val_modal_info
     | Type_declaration

--- a/src/ocaml/typing/msupport.ml
+++ b/src/ocaml/typing/msupport.ml
@@ -40,8 +40,8 @@ let monitor_errors () =
 let raise_error ?(ignore_unify = false) exn =
   !monitor_errors' := true;
   match !errors with
-  | Some (l, _) -> begin
-    match exn with
+  | Some (l, _) ->
+    begin match exn with
     | Ctype.Unify _ when ignore_unify -> ()
     | Ctype.Unify _ | Failure _ ->
       Logger.log ~section:"Typing_aux.raise_error"
@@ -49,7 +49,7 @@ let raise_error ?(ignore_unify = false) exn =
           Printexc.record_backtrace true;
           Format.pp_print_string fmt (Printexc.get_backtrace ()))
     | exn -> l := exn :: !l
-  end
+    end
   | None -> raise exn
 
 let () =
@@ -142,14 +142,13 @@ let rec get_saved_types_from_attributes = function
     let attr, str = Ast_helper.Attr.as_tuple attr in
     if attr = Saved_parts.attribute then
       let open Parsetree in
-      begin
-        match str with
-        | PStr
-            ({ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant key; _ }, _);
-               _
-             }
-            :: _) -> Saved_parts.find key
-        | _ -> []
+      begin match str with
+      | PStr
+          ({ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant key; _ }, _);
+             _
+           }
+          :: _) -> Saved_parts.find key
+      | _ -> []
       end
     else get_saved_types_from_attributes attrs
 
@@ -163,10 +162,9 @@ let with_saved_types ?warning_attribute ?save_part f =
   Cmt_format.set_saved_types [];
   try
     let result = with_warning_attribute ?warning_attribute f in
-    begin
-      match save_part with
-      | None -> ()
-      | Some f -> Cmt_format.set_saved_types (f result :: saved_types)
+    begin match save_part with
+    | None -> ()
+    | Some f -> Cmt_format.set_saved_types (f result :: saved_types)
     end;
     result
   with exn ->

--- a/src/sherlodoc/type_distance.ml
+++ b/src/sherlodoc/type_distance.ml
@@ -52,15 +52,15 @@ let make_path t =
       let prefix = Tyname constr :: prefix in
       args
       |> List.mapi (fun position arg ->
-             let prefix = Argument { position; length } :: prefix in
-             aux prefix arg)
+          let prefix = Argument { position; length } :: prefix in
+          aux prefix arg)
       |> List.fold_left (fun acc xs -> List.rev_append xs acc) []
     | Type_expr.Tuple args ->
       let length = List.length args in
       args
       |> List.mapi (fun position arg ->
-             let prefix = Product { position; length } :: prefix in
-             aux prefix arg)
+          let prefix = Product { position; length } :: prefix in
+          aux prefix arg)
       |> List.fold_left (fun acc xs -> List.rev_append xs acc) []
   in
   List.map List.rev (aux [] t)
@@ -125,8 +125,8 @@ let distance xs ys =
 let make_array list =
   list |> Array.of_list
   |> Array.map (fun li ->
-         let li = List.mapi (fun i x -> (x, i)) li in
-         List.sort Stdlib.compare li)
+      let li = List.mapi (fun i x -> (x, i)) li in
+      List.sort Stdlib.compare li)
 
 let init_heuristic list =
   let used = Array.make List.(length @@ hd list) false in

--- a/src/utils/logger.ml
+++ b/src/utils/logger.ml
@@ -65,11 +65,10 @@ let fmt_handle = Format.formatter_of_buffer fmt_buffer
 
 let fmt () f =
   Buffer.reset fmt_buffer;
-  begin
-    match f fmt_handle with
-    | () -> ()
-    | exception exn ->
-      Format.fprintf fmt_handle "@\nException: %s" (Printexc.to_string exn)
+  begin match f fmt_handle with
+  | () -> ()
+  | exception exn ->
+    Format.fprintf fmt_handle "@\nException: %s" (Printexc.to_string exn)
   end;
   Format.pp_print_flush fmt_handle ();
   let msg = Buffer.contents fmt_buffer in

--- a/src/utils/marg.ml
+++ b/src/utils/marg.ml
@@ -50,8 +50,8 @@ let parse_one ~warning global_spec local_spec args global local =
   | [] -> None
   | arg :: args -> (
     match Hashtbl.find global_spec arg with
-    | action -> begin
-      match action args global with
+    | action ->
+      begin match action args global with
       | args, global -> Some (args, global, local)
       | exception Failure msg ->
         warning ("flag " ^ arg ^ " " ^ msg);
@@ -59,11 +59,11 @@ let parse_one ~warning global_spec local_spec args global local =
       | exception exn ->
         warning ("flag " ^ arg ^ ": error, " ^ Printexc.to_string exn);
         Some (args, global, local)
-    end
+      end
     | exception Not_found -> (
       match assoc3 arg local_spec with
-      | action -> begin
-        match action args local with
+      | action ->
+        begin match action args local with
         | args, local -> Some (args, global, local)
         | exception Failure msg ->
           warning ("flag " ^ arg ^ " " ^ msg);
@@ -71,7 +71,7 @@ let parse_one ~warning global_spec local_spec args global local =
         | exception exn ->
           warning ("flag " ^ arg ^ ": error, " ^ Printexc.to_string exn);
           Some (args, global, local)
-      end
+        end
       | exception Not_found -> None))
 
 let parse_all ~warning global_spec local_spec =
@@ -80,16 +80,16 @@ let parse_all ~warning global_spec local_spec =
     | Some (args, global, local) -> normal_parsing args global local
     | None -> (
       match args with
-      | arg :: args -> begin
+      | arg :: args ->
         (* We split on the first '=' to check if the argument was
            of the form name=value *)
-        try
+        begin try
           let name, value = Misc.cut_at arg '=' in
           normal_parsing (name :: value :: args) global local
         with Not_found ->
           warning ("unknown flag " ^ arg);
           resume_parsing args global local
-      end
+        end
       | [] -> (global, local))
   and resume_parsing args global local =
     let args =

--- a/src/utils/misc.ml
+++ b/src/utils/misc.ml
@@ -868,12 +868,14 @@ let is_print_longer_than size p =
   let out_spaces n = count_down n in
   let out_flush _ = () in
   let out_indent _ = () in
+  let out_width = Format.utf_8_scalar_width in
   let out_functions : Format.formatter_out_functions = {
     out_string;
     out_flush;
     out_newline;
     out_spaces;
-    out_indent}
+    out_indent;
+    out_width}
   in
   let ppf = Format.formatter_of_out_functions out_functions in
   try p ppf; false

--- a/src/utils/sexp.ml
+++ b/src/utils/sexp.ml
@@ -45,23 +45,22 @@ let unescaped str =
       match str.[!i] with
       | '\\' ->
         incr i;
-        begin
-          match str.[!i] with
-          | 'n' -> Buffer.add_char buf '\n'
-          | 'r' -> Buffer.add_char buf '\r'
-          | 't' -> Buffer.add_char buf '\t'
-          | 'x' ->
-            let c0 = Char.code str.[!i + 1] in
-            let c1 = Char.code str.[!i + 2] in
-            Buffer.add_char buf (Char.chr (c0 * 16 lor c1));
-            i := !i + 2
-          | '0' .. '9' ->
-            let c0 = Char.code str.[!i + 1] in
-            let c1 = Char.code str.[!i + 2] in
-            let c2 = Char.code str.[!i + 3] in
-            Buffer.add_char buf (Char.chr (c0 * 64 lor (c1 * 8) lor c2));
-            i := !i + 2
-          | c -> Buffer.add_char buf c
+        begin match str.[!i] with
+        | 'n' -> Buffer.add_char buf '\n'
+        | 'r' -> Buffer.add_char buf '\r'
+        | 't' -> Buffer.add_char buf '\t'
+        | 'x' ->
+          let c0 = Char.code str.[!i + 1] in
+          let c1 = Char.code str.[!i + 2] in
+          Buffer.add_char buf (Char.chr (c0 * 16 lor c1));
+          i := !i + 2
+        | '0' .. '9' ->
+          let c0 = Char.code str.[!i + 1] in
+          let c1 = Char.code str.[!i + 2] in
+          let c2 = Char.code str.[!i + 3] in
+          Buffer.add_char buf (Char.chr (c0 * 64 lor (c1 * 8) lor c2));
+          i := !i + 2
+        | c -> Buffer.add_char buf c
         end;
         incr i
       | c ->
@@ -129,10 +128,9 @@ let read_sexp getch =
         | ' ' | '\t' | '\n' -> aux (getch ())
         | _ -> failwith "Invalid parse"
       in
-      ( begin
-          match next with
-          | Some c -> aux c
-          | None -> aux (getch ())
+      ( begin match next with
+        | Some c -> aux c
+        | None -> aux (getch ())
         end,
         None )
     | c ->

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -177,11 +177,11 @@ module List = struct
   let filter_dup lst = filter_dup' ~equiv:(fun x -> x) lst
 
   let rec merge_cons ~f = function
-    | a :: (b :: tl as tl') -> begin
-      match f a b with
+    | a :: (b :: tl as tl') ->
+      begin match f a b with
       | Some a' -> merge_cons ~f (a' :: tl)
       | None -> a :: merge_cons ~f tl'
-    end
+      end
     | tl -> tl
 
   let rec take_while ~f = function
@@ -409,12 +409,12 @@ module String = struct
       let l' = String.length s in
       l' >= l
       &&
-      try
-        for i = 0 to pred l do
-          if s.[i] <> by.[i] then raise Not_found
-        done;
-        true
-      with Not_found -> false
+        try
+          for i = 0 to pred l do
+            if s.[i] <> by.[i] then raise Not_found
+          done;
+          true
+        with Not_found -> false
 
   (* Drop characters from beginning of string *)
   let drop n s = sub s ~pos:n ~len:(length s - n)
@@ -704,18 +704,17 @@ end = struct
       let l = String.length pattern in
       let i = ref 0 in
       while !i < l do
-        begin
-          match pattern.[!i] with
-          | '\\' ->
-            incr i;
-            if !i < l then Buffer.add_char chunk pattern.[!i]
-          | '*' ->
-            flush ();
-            Buffer.add_string regexp ".*"
-          | '?' ->
-            flush ();
-            Buffer.add_char regexp '.'
-          | x -> Buffer.add_char chunk x
+        begin match pattern.[!i] with
+        | '\\' ->
+          incr i;
+          if !i < l then Buffer.add_char chunk pattern.[!i]
+        | '*' ->
+          flush ();
+          Buffer.add_string regexp ".*"
+        | '?' ->
+          flush ();
+          Buffer.add_char regexp '.'
+        | x -> Buffer.add_char chunk x
         end;
         incr i
       done;
@@ -858,25 +857,21 @@ end
  * - modules_in_path ~ext:".mli" ["."] returns ["A"] *)
 let modules_in_path ~ext path =
   let seen = Hashtbl.create 7 in
-  List.fold_left ~init:[] path
-    ~f:
-      begin
-        fun results dir ->
-          try
-            Array.fold_left
-              begin
-                fun results file ->
-                  if Filename.check_suffix file ext then
-                    let name = Filename.chop_extension file in
-                    if Hashtbl.mem seen name then results
-                    else (
-                      Hashtbl.add seen name ();
-                      String.capitalize name :: results)
-                  else results
-              end
-              results (Sys.readdir dir)
-          with Sys_error _ -> results
-      end
+  List.fold_left ~init:[] path ~f:begin fun results dir ->
+      try
+        Array.fold_left
+          begin fun results file ->
+            if Filename.check_suffix file ext then
+              let name = Filename.chop_extension file in
+              if Hashtbl.mem seen name then results
+              else (
+                Hashtbl.add seen name ();
+                String.capitalize name :: results)
+            else results
+          end
+          results (Sys.readdir dir)
+      with Sys_error _ -> results
+    end
 
 let file_contents filename =
   let ic = open_in filename in

--- a/tests/test-units/kernel/overrides_interval_tree_test.ml
+++ b/tests/test-units/kernel/overrides_interval_tree_test.ml
@@ -6,13 +6,13 @@ let create_position pos_cnum =
 let create_tree intervals =
   intervals
   |> List.map (fun ((low, high), payload) ->
-         let loc =
-           { Location.loc_start = create_position low;
-             loc_end = create_position high;
-             loc_ghost = false
-           }
-         in
-         Result.get_ok (Overrides_interval_tree.Interval.create ~loc ~payload))
+      let loc =
+        { Location.loc_start = create_position low;
+          loc_end = create_position high;
+          loc_ghost = false
+        }
+      in
+      Result.get_ok (Overrides_interval_tree.Interval.create ~loc ~payload))
   |> Overrides_interval_tree.of_alist
 
 let test_of_alist_exn =


### PR DESCRIPTION
Upgrade Merlin to ocaml version 5.4. Unfortunately this comes along with a formatting change. We're forced to upgrade to ocamlformat 0.28.x or 0.29.0, both of which reformat the codebase. 0.28.x has a bug that reformats even more than necessary, so we choose 0.29.0.

I split all the formatting changes out into a separate commit (44e0d247495a9155b82cb86ae7bc03c09f26edd5). I suggest skipping it when reviewing.