### PR TITLE
Update magic number mapping from 35 to 36

### DIFF
--- a/src/ocaml/typing/magic_numbers.ml
+++ b/src/ocaml/typing/magic_numbers.ml
@@ -81,7 +81,7 @@ module Cmi = struct
     | "Caml1999I573" -> Some "5.2.0minus-31"
     | "Caml1999I574" -> Some "5.2.0minus-32"
     | "Caml1999I575" -> Some "5.2.0minus-34"
-    | "Caml1999I576" -> Some "5.2.0minus-35"
+    | "Caml1999I576" -> Some "5.2.0minus-36"
     | _ -> None
 
   let () = assert (to_version_opt Config.cmi_magic_number <> None)


### PR DESCRIPTION
Since we change the compiler tag, `Caml1999I576` is now for `5.2.0minus-36` instead of `5.2.0minus-35`.