### PR TITLE
Improve syntax docs for scannable axes

### DIFF
--- a/src/analysis/completion.ml
+++ b/src/analysis/completion.ml
@@ -139,7 +139,7 @@ let classify_node = function
   | Mode _ | Modality _ | Mod_bound _ ->
     (* CR modes: Have proper completion for modes and modalities *)
     `Expression
-  | Jkind_annotation _ | Jkind_declaration _ ->
+  | Jkind_annotation _ | Jkind_declaration _ | Scannable_axis_annotation _ ->
     (* CR modes: Have proper completion for jkinds *)
     `Type
   | Attribute _ ->

--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -320,6 +320,40 @@ let get_modality_doc (Atom (axis, modality) : Mode.Modality.atom) =
      }
     : syntax_info)
 
+let get_scannable_axis_annotation_doc annot =
+  let open Option.Infix in
+  let* description =
+    match annot with
+    | "non_pointer" -> Some "Values of types of this kind are never pointers."
+    | "non_pointer64" ->
+      Some
+        "Values of types of this kind are never pointers on 64-bit platforms."
+    | "non_float" ->
+      Some "Values of types of this kind are never pointers to floats."
+    | "separable" ->
+      Some
+        "No type of this kind includes both pointers to a float and other \
+         values."
+    | "maybe_separable" ->
+      Some "Types of this kind may mix pointers to floats with other values."
+    | "non_null" ->
+      Some
+        "Values of types of this kind are never the bit pattern containing all \
+         0s."
+    | "maybe_null" ->
+      Some
+        "Values of types of this kind might be the bit pattern containing all \
+         0s."
+    | _ -> None
+  in
+  (Some
+     { name = "Kind Modifier";
+       description;
+       documentation = syntax_doc_url Oxcaml "kinds/syntax/";
+       level = Advanced
+     }
+    : syntax_info)
+
 let get_oxcaml_syntax_doc cursor_loc nodes : syntax_info =
   (* Merlin-jst specific: This function gets documentation for oxcaml language
      extensions. *)
@@ -651,31 +685,14 @@ let get_oxcaml_syntax_doc cursor_loc nodes : syntax_info =
     | _ -> get_modality_doc modality)
   (* Jkinds *)
   | Mod_bound { txt = Mode mod_bound; _ } :: _ -> get_mod_bound_doc mod_bound
-  | Jkind_annotation { pjka_desc = Pjk_abbreviation (abbrev, modifiers); _ }
-    :: _ -> (
+  | Scannable_axis_annotation { txt = annot; _ } :: _ ->
+    get_scannable_axis_annotation_doc annot
+  | Jkind_annotation { pjka_desc = Pjk_abbreviation (abbrev, _); _ }
+    :: _ ->
     (* CR-someday: It isn't ideal that this is based on the parsetree, as this will result
        in an incorrect hint in the presence of shadowing. To properly fix, the compiler
        should introduce a typed jkind into the typedtree. Internal ticket 6600. *)
-    match
-      Loc_comparison_result.is_inside (compare_cursor_to_loc abbrev.loc)
-    with
-    | true -> get_jkind_abbrev_doc abbrev.txt
-    | false ->
-      List.find_opt modifiers ~f:(fun (modifier : _ Location.loc) ->
-          Loc_comparison_result.is_inside (compare_cursor_to_loc modifier.loc))
-      |> Option.bind ~f:(fun (modifier : _ Location.loc) ->
-          match modifier.txt with
-          | "non_pointer" ->
-            (Some
-               { name = "Kind Modifier";
-                 description =
-                   "Modifies a value kind abbreviation to indicate that its \
-                    representation is never a pointer.";
-                 documentation = syntax_doc_url Oxcaml "kinds/syntax/";
-                 level = Advanced
-               }
-              : syntax_info)
-          | _ -> None))
+    get_jkind_abbrev_doc abbrev.txt
   | Jkind_annotation { pjka_desc = Pjk_mod _; _ } :: _ ->
     Some
       { name = "`mod` keyword (in a kind)";

--- a/src/analysis/syntax_doc.ml
+++ b/src/analysis/syntax_doc.ml
@@ -687,8 +687,7 @@ let get_oxcaml_syntax_doc cursor_loc nodes : syntax_info =
   | Mod_bound { txt = Mode mod_bound; _ } :: _ -> get_mod_bound_doc mod_bound
   | Scannable_axis_annotation { txt = annot; _ } :: _ ->
     get_scannable_axis_annotation_doc annot
-  | Jkind_annotation { pjka_desc = Pjk_abbreviation (abbrev, _); _ }
-    :: _ ->
+  | Jkind_annotation { pjka_desc = Pjk_abbreviation (abbrev, _); _ } :: _ ->
     (* CR-someday: It isn't ideal that this is based on the parsetree, as this will result
        in an incorrect hint in the presence of shadowing. To properly fix, the compiler
        should introduce a typed jkind into the typedtree. Internal ticket 6600. *)

--- a/src/ocaml/merlin_specific/browse_raw.ml
+++ b/src/ocaml/merlin_specific/browse_raw.ml
@@ -91,6 +91,7 @@ type node =
   | Jkind_annotation of Parsetree.jkind_annotation
   | Jkind_declaration of Typedtree.jkind_declaration
   | Mod_bound of Parsetree.mode Location.loc
+  | Scannable_axis_annotation of string Location.loc
   | Attribute of attribute
 
 let node_update_env env0 = function
@@ -145,6 +146,7 @@ let node_update_env env0 = function
   | Modality _
   | Jkind_annotation _
   | Jkind_declaration _
+  | Scannable_axis_annotation _
   | Mod_bound _
   | Attribute _ -> env0
 
@@ -184,6 +186,7 @@ let node_real_loc loc0 = function
   | Jkind_annotation { pjka_loc = loc }
   | Jkind_declaration { jkind_loc = loc }
   | Mod_bound { loc }
+  | Scannable_axis_annotation { loc }
   | Attribute { attr_name = { loc } } -> loc
   | Module_type_declaration_name { mtd_name = loc } -> loc.Location.loc
   | Module_declaration_name { md_name = loc }
@@ -304,6 +307,9 @@ let option_fold f' o env (f : _ f0) acc =
 let of_core_type ct = app (Core_type ct)
 
 let of_mod_bound mod_bound = app (Mod_bound mod_bound)
+
+let of_scannable_axis_annotation scannable_axis_annotation =
+  app (Scannable_axis_annotation scannable_axis_annotation)
 
 let of_mode mode = app (Mode mode)
 
@@ -703,7 +709,9 @@ let of_jkind_annotation_desc : Parsetree.jkind_annotation_desc -> _ =
     id_fold
   in
   function
-  | Pjk_default | Pjk_abbreviation _ -> id_fold
+  | Pjk_default -> id_fold
+  | Pjk_abbreviation (_, scannable_axis_annotations) ->
+    list_fold of_scannable_axis_annotation scannable_axis_annotations
   | Pjk_mod (jkind, mod_bounds) ->
     of_jkind_annotation jkind ** list_fold of_mod_bound mod_bounds
   | Pjk_with (jkind, ct, modalities) ->
@@ -848,6 +856,7 @@ let of_node node =
     | Jkind_declaration { jkind_annotation } ->
       option_fold of_jkind_annotation jkind_annotation
     | Mod_bound _ -> id_fold
+    | Scannable_axis_annotation _ -> id_fold
     | Attribute _ -> id_fold
   in
   without_attributes ** list_fold of_attribute (node_attributes node)
@@ -911,6 +920,7 @@ let string_of_node = function
   | Jkind_annotation _ -> "jkind_annotation"
   | Jkind_declaration _ -> "jkind_declaration"
   | Mod_bound _ -> "mod_bound"
+  | Scannable_axis_annotation _ -> "scannable_axis_annotation"
   | Attribute _ -> "attribute"
 
 let mkloc = Location.mkloc

--- a/src/ocaml/merlin_specific/browse_raw.mli
+++ b/src/ocaml/merlin_specific/browse_raw.mli
@@ -104,6 +104,7 @@ type node =
   | Jkind_annotation of Parsetree.jkind_annotation
   | Jkind_declaration of jkind_declaration
   | Mod_bound of Parsetree.mode Location.loc
+  | Scannable_axis_annotation of string Location.loc
   | Attribute of attribute
       (** The location of an [Attribute] is considered to be the location of the
           [attr_name], not the overall attribute. This is because in an [Mbrowse.t], an


### PR DESCRIPTION
This PR adds better support for scannable axes to Merlin's syntax-doc feature