### PR TITLE
Update flake to use OCaml 5.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,17 +39,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1771129128,
+        "narHash": "sha256-zi224RqZ0dlo44oOMJTzQiRdNa5sJ2UjGiDgpK4xJeM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "626a1db9776eb9db61b1e1f394d928505162cf69",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "626a1db9776eb9db61b1e1f394d928505162cf69",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Merlin Nix Flake";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/626a1db9776eb9db61b1e1f394d928505162cf69";
   inputs.menhir-repository = {
     url = "gitlab:fpottier/menhir/20231231?host=gitlab.inria.fr";
     flake = false;
@@ -20,8 +20,8 @@
       let
         pkgs = nixpkgs.legacyPackages."${system}";
 
-        # Build with OCaml 5.2
-        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_5_2.overrideScope (
+        # Build with OCaml 5.4
+        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_5_4.overrideScope (
           _: osuper: {
             # Override menhirLib to the pinned version
             menhirLib = osuper.menhirLib.overrideAttrs (_: {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Merlin Nix Flake";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  # Tip of nixos-24.11 as of 2026-02-14, chosen as the last revision before `menhir` added a `menhirGLR` package.
   inputs.nixpkgs.url = "github:nixos/nixpkgs/626a1db9776eb9db61b1e1f394d928505162cf69";
   inputs.menhir-repository = {
     url = "gitlab:fpottier/menhir/20231231?host=gitlab.inria.fr";


### PR DESCRIPTION
The version of OCaml used to build Merlin was updated from 5.2 -> 5.4, but the Nix file remained on 5.2.

I've pinned the version of NixPkgs to Feb 14, which is *before* Menhir added a new package, `menhirGLR`, which was causing all sorts of build issues. This is the only way I know of to get around the new package, suggestions more than welcome.